### PR TITLE
Fix Chrome drop-shadow rendering artifacts on hero/parallax text

### DIFF
--- a/packages/tallcms/cms/resources/views/cms/blocks/hero.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/hero.blade.php
@@ -101,7 +101,7 @@
             class="{{ $textColorClass }} {{ ($layout ?? 'centered') === 'centered' ? 'max-w-5xl mx-auto' : 'flex-1' }} {{ ($layout ?? 'centered') !== 'centered' ? ($text_alignment ?? 'text-left') : '' }}"
         >
             @if($heading ?? null)
-                <h1 class="text-4xl sm:text-5xl lg:text-6xl xl:text-7xl font-bold leading-tight mb-6 drop-shadow-lg">
+                <h1 class="text-4xl sm:text-5xl lg:text-6xl xl:text-7xl font-bold leading-tight mb-6" style="text-shadow: 0 4px 8px rgba(0,0,0,0.25)">
                     {!! $processedHeading !!}
                 </h1>
             @endif

--- a/packages/tallcms/cms/resources/views/cms/blocks/parallax.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/parallax.blade.php
@@ -66,13 +66,13 @@
         <div class="relative z-10 h-full flex flex-col {{ $justifyClass }} {{ $itemsClass }} {{ $textAlign }} px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
             <div class="max-w-4xl {{ $textAlign === 'text-center' ? 'mx-auto' : ($textAlign === 'text-right' ? 'ml-auto' : '') }}">
                 @if(!empty($heading))
-                    <h2 class="text-3xl sm:text-4xl lg:text-5xl font-bold text-white mb-4 drop-shadow-lg">
+                    <h2 class="text-3xl sm:text-4xl lg:text-5xl font-bold text-white mb-4" style="text-shadow: 0 4px 8px rgba(0,0,0,0.25)">
                         {{ $heading }}
                     </h2>
                 @endif
 
                 @if(!empty($subheading))
-                    <p class="text-lg sm:text-xl text-white/90 mb-8 max-w-2xl {{ $textAlign === 'text-center' ? 'mx-auto' : '' }} drop-shadow">
+                    <p class="text-lg sm:text-xl text-white/90 mb-8 max-w-2xl {{ $textAlign === 'text-center' ? 'mx-auto' : '' }}" style="text-shadow: 0 1px 3px rgba(0,0,0,0.3)">
                         {{ $subheading }}
                     </p>
                 @endif

--- a/resources/views/cms/blocks/hero.blade.php
+++ b/resources/views/cms/blocks/hero.blade.php
@@ -80,7 +80,7 @@
         {{-- Text Content - textColorClass scoped HERE only --}}
         <div class="{{ $textColorClass }} {{ ($layout ?? 'centered') === 'centered' ? 'max-w-5xl mx-auto' : 'flex-1' }} {{ ($layout ?? 'centered') !== 'centered' ? ($text_alignment ?? 'text-left') : '' }}">
             @if($heading ?? null)
-                <h1 class="text-4xl sm:text-5xl lg:text-6xl xl:text-7xl font-bold leading-tight mb-6 drop-shadow-lg">
+                <h1 class="text-4xl sm:text-5xl lg:text-6xl xl:text-7xl font-bold leading-tight mb-6" style="text-shadow: 0 4px 8px rgba(0,0,0,0.25)">
                     {!! $processedHeading !!}
                 </h1>
             @endif


### PR DESCRIPTION
## Summary
- Replace Tailwind's `drop-shadow-lg` / `drop-shadow` (CSS `filter: drop-shadow()`) with inline `text-shadow` on hero and parallax block headings
- Fixes a Chrome rendering bug where white artifacts appear at letter corners on large text, depending on GPU/zoom level
- `text-shadow` is also the semantically correct property for text content and avoids unnecessary compositing layers

## Files changed
- `packages/tallcms/cms/resources/views/cms/blocks/hero.blade.php`
- `packages/tallcms/cms/resources/views/cms/blocks/parallax.blade.php`
- `resources/views/cms/blocks/hero.blade.php` (app override)

## Test plan
- [ ] Verify hero block heading shadow looks correct on frontend
- [ ] Verify parallax block heading/subheading shadow looks correct
- [ ] Check in Chrome with various zoom levels (100%, 110%, 125%)
- [ ] Confirm no visual regression in Firefox/Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)