### PR TITLE
Feature/configurable resource labels

### DIFF
--- a/packages/tallcms/cms/config/tallcms.php
+++ b/packages/tallcms/cms/config/tallcms.php
@@ -196,6 +196,31 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Resource Labels
+    |--------------------------------------------------------------------------
+    |
+    | Admin panel singular, plural, and navigation labels for each resource.
+    | Override any key to rename a resource without touching package files.
+    | In plugin mode, prefer the TallCmsPlugin fluent API:
+    |   TallCmsPlugin::make()->categoryLabel('Tags', 'Tag')
+    | Direct config overrides in your app's config/tallcms.php also work.
+    |
+    */
+    'labels' => [
+        'categories'          => ['singular' => 'Category',           'plural' => 'Categories',           'navigation' => 'Categories'],
+        'pages'               => ['singular' => 'Page',               'plural' => 'Pages',                'navigation' => 'Pages'],
+        'posts'               => ['singular' => 'Post',               'plural' => 'Posts',                'navigation' => 'Posts'],
+        'menus'               => ['singular' => 'Menu',               'plural' => 'Menus',                'navigation' => 'Menus'],
+        'media'               => ['singular' => 'Media File',         'plural' => 'Media Files',          'navigation' => 'Media Library'],
+        'media_collections'   => ['singular' => 'Collection',         'plural' => 'Collections',          'navigation' => 'Collections'],
+        'comments'            => ['singular' => 'Comment',            'plural' => 'Comments',             'navigation' => 'Comments'],
+        'contact_submissions' => ['singular' => 'Contact Submission', 'plural' => 'Contact Submissions',  'navigation' => 'Contact Submissions'],
+        'users'               => ['singular' => 'User',               'plural' => 'Users',                'navigation' => 'Users'],
+        'site_settings'       => ['singular' => 'Site',               'plural' => 'Sites',                'navigation' => 'Site Settings'],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Contact Information
     |--------------------------------------------------------------------------
     |

--- a/packages/tallcms/cms/config/tallcms.php
+++ b/packages/tallcms/cms/config/tallcms.php
@@ -207,16 +207,56 @@ return [
     |
     */
     'labels' => [
-        'categories'          => ['singular' => 'Category',           'plural' => 'Categories',           'navigation' => 'Categories'],
-        'pages'               => ['singular' => 'Page',               'plural' => 'Pages',                'navigation' => 'Pages'],
-        'posts'               => ['singular' => 'Post',               'plural' => 'Posts',                'navigation' => 'Posts'],
-        'menus'               => ['singular' => 'Menu',               'plural' => 'Menus',                'navigation' => 'Menus'],
-        'media'               => ['singular' => 'Media File',         'plural' => 'Media Files',          'navigation' => 'Media Library'],
-        'media_collections'   => ['singular' => 'Collection',         'plural' => 'Collections',          'navigation' => 'Collections'],
-        'comments'            => ['singular' => 'Comment',            'plural' => 'Comments',             'navigation' => 'Comments'],
-        'contact_submissions' => ['singular' => 'Contact Submission', 'plural' => 'Contact Submissions',  'navigation' => 'Contact Submissions'],
-        'users'               => ['singular' => 'User',               'plural' => 'Users',                'navigation' => 'Users'],
-        'site_settings'       => ['singular' => 'Site',               'plural' => 'Sites',                'navigation' => 'Site Settings'],
+        'categories' => [
+            'singular'   => 'Category',
+            'plural'     => 'Categories',
+            'navigation' => 'Categories',
+        ],
+        'pages' => [
+            'singular'   => 'Page',
+            'plural'     => 'Pages',
+            'navigation' => 'Pages',
+        ],
+        'posts' => [
+            'singular'   => 'Post',
+            'plural'     => 'Posts',
+            'navigation' => 'Posts',
+        ],
+        'menus' => [
+            'singular'   => 'Menu',
+            'plural'     => 'Menus',
+            'navigation' => 'Menus',
+        ],
+        'media' => [
+            'singular'   => 'Media File',
+            'plural'     => 'Media Files',
+            'navigation' => 'Media Library',
+        ],
+        'media_collections' => [
+            'singular'   => 'Collection',
+            'plural'     => 'Collections',
+            'navigation' => 'Collections',
+        ],
+        'comments' => [
+            'singular'   => 'Comment',
+            'plural'     => 'Comments',
+            'navigation' => 'Comments',
+        ],
+        'contact_submissions' => [
+            'singular'   => 'Contact Submission',
+            'plural'     => 'Contact Submissions',
+            'navigation' => 'Contact Submissions',
+        ],
+        'users' => [
+            'singular'   => 'User',
+            'plural'     => 'Users',
+            'navigation' => 'Users',
+        ],
+        'site_settings' => [
+            'singular'   => 'Site',
+            'plural'     => 'Sites',
+            'navigation' => 'Site Settings',
+        ],
     ],
 
     /*

--- a/packages/tallcms/cms/src/Filament/Resources/CmsCategories/CmsCategoryResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsCategories/CmsCategoryResource.php
@@ -21,8 +21,6 @@ class CmsCategoryResource extends Resource
 
     protected static ?string $model = CmsCategory::class;
 
-    protected static ?string $pluralModelLabel = 'Categories';
-
     public static function form(Schema $schema): Schema
     {
         return CmsCategoryForm::configure($schema);
@@ -59,9 +57,19 @@ class CmsCategoryResource extends Resource
         return config('tallcms.navigation.groups.content', 'Content');
     }
 
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.categories.singular', 'Category');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.categories.plural', 'Categories');
+    }
+
     public static function getNavigationLabel(): string
     {
-        return 'Categories';
+        return config('tallcms.labels.categories.navigation', 'Categories');
     }
 
     public static function getNavigationSort(): ?int

--- a/packages/tallcms/cms/src/Filament/Resources/CmsComments/CmsCommentResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsComments/CmsCommentResource.php
@@ -18,18 +18,24 @@ class CmsCommentResource extends Resource
 
     protected static ?string $model = CmsComment::class;
 
-    protected static ?string $modelLabel = 'Comment';
-
-    protected static ?string $pluralModelLabel = 'Comments';
-
     public static function getNavigationIcon(): string
     {
         return 'heroicon-o-chat-bubble-left-right';
     }
 
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.comments.singular', 'Comment');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.comments.plural', 'Comments');
+    }
+
     public static function getNavigationLabel(): string
     {
-        return 'Comments';
+        return config('tallcms.labels.comments.navigation', 'Comments');
     }
 
     public static function getNavigationGroup(): ?string

--- a/packages/tallcms/cms/src/Filament/Resources/CmsPages/CmsPageResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsPages/CmsPageResource.php
@@ -22,8 +22,6 @@ class CmsPageResource extends Resource
 
     protected static ?string $model = CmsPage::class;
 
-    protected static ?string $pluralModelLabel = 'Pages';
-
     // Title attribute enables global search automatically
     protected static ?string $recordTitleAttribute = 'title';
 
@@ -85,9 +83,19 @@ class CmsPageResource extends Resource
         return config('tallcms.navigation.groups.content', 'Content');
     }
 
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.pages.singular', 'Page');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.pages.plural', 'Pages');
+    }
+
     public static function getNavigationLabel(): string
     {
-        return 'Pages';
+        return config('tallcms.labels.pages.navigation', 'Pages');
     }
 
     public static function getNavigationSort(): ?int

--- a/packages/tallcms/cms/src/Filament/Resources/CmsPages/CmsPageResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsPages/CmsPageResource.php
@@ -133,7 +133,7 @@ class CmsPageResource extends Resource
     public static function getGlobalSearchResultDetails(Model $record): array
     {
         return [
-            __('Type') => __('Page'),
+            __('Type') => static::getModelLabel(),
             __('Status') => __(ucfirst($record->status ?? 'draft')),
         ];
     }

--- a/packages/tallcms/cms/src/Filament/Resources/CmsPosts/CmsPostResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsPosts/CmsPostResource.php
@@ -22,8 +22,6 @@ class CmsPostResource extends Resource
 
     protected static ?string $model = CmsPost::class;
 
-    protected static ?string $pluralModelLabel = 'Posts';
-
     // Title attribute enables global search automatically
     protected static ?string $recordTitleAttribute = 'title';
 
@@ -66,9 +64,19 @@ class CmsPostResource extends Resource
         return config('tallcms.navigation.groups.content', 'Content');
     }
 
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.posts.singular', 'Post');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.posts.plural', 'Posts');
+    }
+
     public static function getNavigationLabel(): string
     {
-        return 'Posts';
+        return config('tallcms.labels.posts.navigation', 'Posts');
     }
 
     public static function getNavigationSort(): ?int

--- a/packages/tallcms/cms/src/Filament/Resources/CmsPosts/CmsPostResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsPosts/CmsPostResource.php
@@ -130,7 +130,7 @@ class CmsPostResource extends Resource
     public static function getGlobalSearchResultDetails(Model $record): array
     {
         return [
-            __('Type') => __('Post'),
+            __('Type') => static::getModelLabel(),
             __('Status') => __(ucfirst($record->status ?? 'draft')),
             __('Author') => $record->author?->name ?? __('Unknown'),
         ];

--- a/packages/tallcms/cms/src/Filament/Resources/MediaCollection/MediaCollectionResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/MediaCollection/MediaCollectionResource.php
@@ -27,13 +27,25 @@ class MediaCollectionResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedFolderOpen;
 
-    protected static ?string $navigationLabel = 'Collections';
+    public static function getNavigationLabel(): string
+    {
+        return config('tallcms.labels.media_collections.navigation', 'Collections');
+    }
 
-    protected static ?string $modelLabel = 'Collection';
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.media_collections.singular', 'Collection');
+    }
 
-    protected static ?string $pluralModelLabel = 'Collections';
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.media_collections.plural', 'Collections');
+    }
 
-    protected static ?string $navigationParentItem = 'Media Library';
+    public static function getNavigationParentItem(): ?string
+    {
+        return config('tallcms.labels.media.navigation', 'Media Library');
+    }
 
     public static function getNavigationGroup(): ?string
     {

--- a/packages/tallcms/cms/src/Filament/Resources/SiteResource/SiteResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/SiteResource/SiteResource.php
@@ -22,11 +22,22 @@ class SiteResource extends Resource
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-cog-8-tooth';
 
-    protected static ?string $navigationLabel = 'Site Settings';
-
-    protected static ?string $modelLabel = 'Site';
-
     protected static ?int $navigationSort = 40;
+
+    public static function getNavigationLabel(): string
+    {
+        return config('tallcms.labels.site_settings.navigation', 'Site Settings');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.site_settings.singular', 'Site');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.site_settings.plural', 'Sites');
+    }
 
     public static function getNavigationGroup(): ?string
     {

--- a/packages/tallcms/cms/src/Filament/Resources/TallcmsContactSubmissions/TallcmsContactSubmissionResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/TallcmsContactSubmissions/TallcmsContactSubmissionResource.php
@@ -17,18 +17,24 @@ class TallcmsContactSubmissionResource extends Resource
 
     protected static ?string $model = TallcmsContactSubmission::class;
 
-    protected static ?string $modelLabel = 'Contact Submission';
-
-    protected static ?string $pluralModelLabel = 'Contact Submissions';
-
     public static function getNavigationIcon(): string
     {
         return 'heroicon-o-envelope';
     }
 
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.contact_submissions.singular', 'Contact Submission');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.contact_submissions.plural', 'Contact Submissions');
+    }
+
     public static function getNavigationLabel(): string
     {
-        return 'Contact Submissions';
+        return config('tallcms.labels.contact_submissions.navigation', 'Contact Submissions');
     }
 
     public static function getNavigationGroup(): ?string

--- a/packages/tallcms/cms/src/Filament/Resources/TallcmsMedia/TallcmsMediaResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/TallcmsMedia/TallcmsMediaResource.php
@@ -21,11 +21,20 @@ class TallcmsMediaResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
 
-    protected static ?string $navigationLabel = 'Media Library';
+    public static function getNavigationLabel(): string
+    {
+        return config('tallcms.labels.media.navigation', 'Media Library');
+    }
 
-    protected static ?string $modelLabel = 'Media File';
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.media.singular', 'Media File');
+    }
 
-    protected static ?string $pluralModelLabel = 'Media Files';
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.media.plural', 'Media Files');
+    }
 
     public static function getNavigationGroup(): ?string
     {

--- a/packages/tallcms/cms/src/Filament/Resources/TallcmsMenus/TallcmsMenuResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/TallcmsMenus/TallcmsMenuResource.php
@@ -20,11 +20,20 @@ class TallcmsMenuResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
 
-    protected static ?string $navigationLabel = 'Menus';
+    public static function getNavigationLabel(): string
+    {
+        return config('tallcms.labels.menus.navigation', 'Menus');
+    }
 
-    protected static ?string $modelLabel = 'Menu';
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.menus.singular', 'Menu');
+    }
 
-    protected static ?string $pluralModelLabel = 'Menus';
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.menus.plural', 'Menus');
+    }
 
     public static function shouldRegisterNavigation(): bool
     {

--- a/packages/tallcms/cms/src/Filament/Resources/Users/UserResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/Users/UserResource.php
@@ -19,9 +19,20 @@ class UserResource extends Resource
 {
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedUsers;
 
-    protected static ?string $modelLabel = 'User';
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.users.singular', 'User');
+    }
 
-    protected static ?string $pluralModelLabel = 'Users';
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.users.plural', 'Users');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return config('tallcms.labels.users.navigation', 'Users');
+    }
 
     public static function getModel(): string
     {

--- a/packages/tallcms/cms/src/TallCmsPlugin.php
+++ b/packages/tallcms/cms/src/TallCmsPlugin.php
@@ -7,6 +7,7 @@ namespace TallCms\Cms;
 use BezhanSalleh\FilamentShield\FilamentShieldPlugin;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
 use LaraZeus\SpatieTranslatable\SpatieTranslatablePlugin;
 use TallCms\Cms\Filament\Pages\ApiTokens;
@@ -72,6 +73,9 @@ class TallCmsPlugin implements Plugin
 
     protected ?string $shieldNavigationGroup = null; // Set dynamically from config
 
+    /** @var array<string, array{singular?: string, plural?: string, navigation?: string}> */
+    protected array $labelOverrides = [];
+
     public static function make(): static
     {
         return app(static::class);
@@ -92,6 +96,12 @@ class TallCmsPlugin implements Plugin
 
     public function register(Panel $panel): void
     {
+        foreach ($this->labelOverrides as $key => $labels) {
+            foreach ($labels as $type => $value) {
+                Config::set("tallcms.labels.{$key}.{$type}", $value);
+            }
+        }
+
         $panel
             ->resources($this->getResources())
             ->pages($this->getPages())
@@ -545,6 +555,108 @@ class TallCmsPlugin implements Plugin
     public function shieldNavigationGroup(?string $group): static
     {
         $this->shieldNavigationGroup = $group;
+
+        return $this;
+    }
+
+    /**
+     * Rename the Categories resource labels.
+     *
+     * Example: ->categoryLabel('Tags', 'Tag')
+     */
+    public function categoryLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('categories', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Pages resource labels.
+     *
+     * Example: ->pageLabel('Website Pages', 'Website Page')
+     */
+    public function pageLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('pages', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Posts resource labels.
+     *
+     * Example: ->postLabel('Articles', 'Article')
+     */
+    public function postLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('posts', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Menus resource labels.
+     */
+    public function menuLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('menus', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Media resource labels.
+     */
+    public function mediaLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('media', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Media Collections resource labels.
+     */
+    public function mediaCollectionLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('media_collections', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Comments resource labels.
+     */
+    public function commentLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('comments', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Contact Submissions resource labels.
+     */
+    public function contactSubmissionLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('contact_submissions', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Users resource labels.
+     */
+    public function userLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('users', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Site Settings resource labels.
+     */
+    public function siteSettingsLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('site_settings', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Store label overrides for a resource key.
+     * $navigation defaults to $plural when not provided.
+     * $singular defaults to $plural when not provided.
+     */
+    protected function setResourceLabels(string $key, string $plural, ?string $singular, ?string $navigation): static
+    {
+        $this->labelOverrides[$key] = [
+            'plural' => $plural,
+            'singular' => $singular ?? $plural,
+            'navigation' => $navigation ?? $plural,
+        ];
 
         return $this;
     }

--- a/packages/tallcms/cms/src/TallCmsPlugin.php
+++ b/packages/tallcms/cms/src/TallCmsPlugin.php
@@ -647,16 +647,27 @@ class TallCmsPlugin implements Plugin
 
     /**
      * Store label overrides for a resource key.
-     * $navigation defaults to $plural when not provided.
-     * $singular defaults to $plural when not provided.
+     *
+     * Only provided (non-null) values are written; omitted ones preserve
+     * the existing config default. This matters because the default
+     * navigation label is intentionally different from plural for some
+     * resources (e.g. media -> "Media Library", site_settings ->
+     * "Site Settings"), and the singular form is usually not the same
+     * word as the plural ("Article" vs "Articles").
      */
     protected function setResourceLabels(string $key, string $plural, ?string $singular, ?string $navigation): static
     {
-        $this->labelOverrides[$key] = [
-            'plural' => $plural,
-            'singular' => $singular ?? $plural,
-            'navigation' => $navigation ?? $plural,
-        ];
+        $overrides = ['plural' => $plural];
+
+        if ($singular !== null) {
+            $overrides['singular'] = $singular;
+        }
+
+        if ($navigation !== null) {
+            $overrides['navigation'] = $navigation;
+        }
+
+        $this->labelOverrides[$key] = $overrides;
 
         return $this;
     }

--- a/packages/tallcms/cms/tests/Feature/ResourceLabelOverrideTest.php
+++ b/packages/tallcms/cms/tests/Feature/ResourceLabelOverrideTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace TallCms\Cms\Tests\Feature;
+
+use Filament\Panel;
+use PHPUnit\Framework\Attributes\DataProvider;
+use TallCms\Cms\Filament\Resources\CmsCategories\CmsCategoryResource;
+use TallCms\Cms\Filament\Resources\CmsComments\CmsCommentResource;
+use TallCms\Cms\Filament\Resources\CmsPages\CmsPageResource;
+use TallCms\Cms\Filament\Resources\CmsPosts\CmsPostResource;
+use TallCms\Cms\Filament\Resources\MediaCollection\MediaCollectionResource;
+use TallCms\Cms\Filament\Resources\SiteResource\SiteResource;
+use TallCms\Cms\Filament\Resources\TallcmsContactSubmissions\TallcmsContactSubmissionResource;
+use TallCms\Cms\Filament\Resources\TallcmsMedia\TallcmsMediaResource;
+use TallCms\Cms\Filament\Resources\TallcmsMenus\TallcmsMenuResource;
+use TallCms\Cms\Filament\Resources\Users\UserResource;
+use TallCms\Cms\TallCmsPlugin;
+use TallCms\Cms\Tests\TestCase;
+
+/**
+ * Contract tests for the configurable resource labels feature (PR #57).
+ *
+ * Plugin-mode adopters need to rename admin resources to match their
+ * domain — "Articles" instead of "Posts", "Tags" instead of "Categories",
+ * etc. Each resource's singular/plural/navigation labels are exposed via
+ * `tallcms.labels.<key>.<facet>` config, with a fluent API on TallCmsPlugin
+ * for convenience. These tests lock the contract so a future refactor
+ * doesn't silently break renaming.
+ */
+class ResourceLabelOverrideTest extends TestCase
+{
+    #[DataProvider('resourceMatrix')]
+    public function test_resource_reads_all_three_labels_from_config(
+        string $configKey,
+        string $resource,
+        string $singular,
+        string $plural,
+        string $navigation,
+    ): void {
+        config(['tallcms.labels.'.$configKey => [
+            'singular' => $singular,
+            'plural' => $plural,
+            'navigation' => $navigation,
+        ]]);
+
+        $this->assertSame($singular, $resource::getModelLabel());
+        $this->assertSame($plural, $resource::getPluralModelLabel());
+        $this->assertSame($navigation, $resource::getNavigationLabel());
+    }
+
+    public static function resourceMatrix(): array
+    {
+        return [
+            'categories' => ['categories', CmsCategoryResource::class, 'Tag', 'Tags', 'Tags'],
+            'pages' => ['pages', CmsPageResource::class, 'Listing', 'Listings', 'Listings'],
+            'posts' => ['posts', CmsPostResource::class, 'Article', 'Articles', 'Articles'],
+            'menus' => ['menus', TallcmsMenuResource::class, 'Nav', 'Nav Menus', 'Nav Menus'],
+            'media' => ['media', TallcmsMediaResource::class, 'Asset', 'Assets', 'Asset Library'],
+            'media_collections' => ['media_collections', MediaCollectionResource::class, 'Album', 'Albums', 'Albums'],
+            'comments' => ['comments', CmsCommentResource::class, 'Reply', 'Replies', 'Replies'],
+            'contact_submissions' => ['contact_submissions', TallcmsContactSubmissionResource::class, 'Lead', 'Leads', 'Leads'],
+            'users' => ['users', UserResource::class, 'Member', 'Members', 'Members'],
+            'site_settings' => ['site_settings', SiteResource::class, 'Property', 'Properties', 'Property Settings'],
+        ];
+    }
+
+    public function test_defaults_apply_when_no_override_is_configured(): void
+    {
+        // Restore config to known defaults for a known resource and
+        // assert the resource honors them (proves the fallback branch).
+        config(['tallcms.labels.categories' => [
+            'singular' => 'Category',
+            'plural' => 'Categories',
+            'navigation' => 'Categories',
+        ]]);
+
+        $this->assertSame('Category', CmsCategoryResource::getModelLabel());
+        $this->assertSame('Categories', CmsCategoryResource::getPluralModelLabel());
+        $this->assertSame('Categories', CmsCategoryResource::getNavigationLabel());
+    }
+
+    public function test_fluent_api_only_overwrites_plural_when_singular_and_navigation_are_omitted(): void
+    {
+        // This is the bug the review flagged: a call like
+        // ->postLabel('Articles') must NOT coerce singular/navigation to
+        // "Articles" too. It should only rename the plural and leave
+        // singular/navigation at their configured defaults, so UI reads
+        // "Create Article" / "Edit Article", not "Create Articles".
+        config(['tallcms.labels.posts' => [
+            'singular' => 'Post',
+            'plural' => 'Posts',
+            'navigation' => 'Posts',
+        ]]);
+
+        $plugin = TallCmsPlugin::make()->postLabel('Articles');
+
+        $this->invokeRegister($plugin);
+
+        $this->assertSame('Articles', config('tallcms.labels.posts.plural'),
+            'Plural should be overwritten with the passed value.');
+        $this->assertSame('Post', config('tallcms.labels.posts.singular'),
+            'Singular should remain at its configured default when omitted.');
+        $this->assertSame('Posts', config('tallcms.labels.posts.navigation'),
+            'Navigation should remain at its configured default when omitted.');
+    }
+
+    public function test_fluent_api_persists_all_three_labels_when_fully_specified(): void
+    {
+        config(['tallcms.labels.posts' => [
+            'singular' => 'Post',
+            'plural' => 'Posts',
+            'navigation' => 'Posts',
+        ]]);
+
+        $plugin = TallCmsPlugin::make()->postLabel('Articles', 'Article', 'News');
+
+        $this->invokeRegister($plugin);
+
+        $this->assertSame('Article', config('tallcms.labels.posts.singular'));
+        $this->assertSame('Articles', config('tallcms.labels.posts.plural'));
+        $this->assertSame('News', config('tallcms.labels.posts.navigation'));
+    }
+
+    public function test_fluent_api_preserves_distinct_navigation_default_for_media_resource(): void
+    {
+        // `media`'s default navigation label ("Media Library") is
+        // intentionally different from its plural ("Media Files") —
+        // a partial override must not flatten the library distinction.
+        config(['tallcms.labels.media' => [
+            'singular' => 'Media File',
+            'plural' => 'Media Files',
+            'navigation' => 'Media Library',
+        ]]);
+
+        $plugin = TallCmsPlugin::make()->mediaLabel('Assets');
+
+        $this->invokeRegister($plugin);
+
+        $this->assertSame('Assets', config('tallcms.labels.media.plural'));
+        $this->assertSame('Media File', config('tallcms.labels.media.singular'));
+        $this->assertSame('Media Library', config('tallcms.labels.media.navigation'),
+            'The "Library" concept in the default navigation label must survive a partial rename.');
+    }
+
+    public function test_global_search_type_metadata_reflects_renamed_post_label(): void
+    {
+        config(['tallcms.labels.posts.singular' => 'Article']);
+
+        $post = new \TallCms\Cms\Models\CmsPost;
+        $post->status = 'published';
+
+        $details = CmsPostResource::getGlobalSearchResultDetails($post);
+
+        $this->assertSame('Article', $details[__('Type')],
+            'Global search "Type" metadata must reflect the renamed label, '.
+            'not a hardcoded "Post" string.');
+    }
+
+    public function test_global_search_type_metadata_reflects_renamed_page_label(): void
+    {
+        config(['tallcms.labels.pages.singular' => 'Listing']);
+
+        $page = new \TallCms\Cms\Models\CmsPage;
+        $page->status = 'published';
+
+        $details = CmsPageResource::getGlobalSearchResultDetails($page);
+
+        $this->assertSame('Listing', $details[__('Type')],
+            'Global search "Type" metadata must reflect the renamed label, '.
+            'not a hardcoded "Page" string.');
+    }
+
+    protected function invokeRegister(TallCmsPlugin $plugin): void
+    {
+        // The full register() pipeline touches FilamentShieldPlugin and
+        // Spatie Translatable registration paths that aren't relevant
+        // here. Stub Panel with self-returning methods and swallow any
+        // late-stage exception — the only contract we care about is that
+        // the label overrides are pushed to config early in register().
+        $panel = $this->createMock(Panel::class);
+        $panel->method('resources')->willReturnSelf();
+        $panel->method('pages')->willReturnSelf();
+        $panel->method('widgets')->willReturnSelf();
+        $panel->method('plugin')->willReturnSelf();
+        $panel->method('plugins')->willReturnSelf();
+
+        try {
+            $plugin->register($panel);
+        } catch (\Throwable) {
+            // Expected: late-stage plugin registration requires a full
+            // Filament panel bootstrap. Config mutation has already run.
+        }
+    }
+}


### PR DESCRIPTION
Plugin-mode users can now rename any admin resource label (nav label,
singular, plural) without forking package files.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>