### PR TITLE
Feature/hierarchical page urls

### DIFF
--- a/packages/tallcms/cms/config/tallcms.php
+++ b/packages/tallcms/cms/config/tallcms.php
@@ -196,6 +196,31 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Resource Labels
+    |--------------------------------------------------------------------------
+    |
+    | Admin panel singular, plural, and navigation labels for each resource.
+    | Override any key to rename a resource without touching package files.
+    | In plugin mode, prefer the TallCmsPlugin fluent API:
+    |   TallCmsPlugin::make()->categoryLabel('Tags', 'Tag')
+    | Direct config overrides in your app's config/tallcms.php also work.
+    |
+    */
+    'labels' => [
+        'categories'          => ['singular' => 'Category',           'plural' => 'Categories',           'navigation' => 'Categories'],
+        'pages'               => ['singular' => 'Page',               'plural' => 'Pages',                'navigation' => 'Pages'],
+        'posts'               => ['singular' => 'Post',               'plural' => 'Posts',                'navigation' => 'Posts'],
+        'menus'               => ['singular' => 'Menu',               'plural' => 'Menus',                'navigation' => 'Menus'],
+        'media'               => ['singular' => 'Media File',         'plural' => 'Media Files',          'navigation' => 'Media Library'],
+        'media_collections'   => ['singular' => 'Collection',         'plural' => 'Collections',          'navigation' => 'Collections'],
+        'comments'            => ['singular' => 'Comment',            'plural' => 'Comments',             'navigation' => 'Comments'],
+        'contact_submissions' => ['singular' => 'Contact Submission', 'plural' => 'Contact Submissions',  'navigation' => 'Contact Submissions'],
+        'users'               => ['singular' => 'User',               'plural' => 'Users',                'navigation' => 'Users'],
+        'site_settings'       => ['singular' => 'Site',               'plural' => 'Sites',                'navigation' => 'Site Settings'],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Contact Information
     |--------------------------------------------------------------------------
     |

--- a/packages/tallcms/cms/config/tallcms.php
+++ b/packages/tallcms/cms/config/tallcms.php
@@ -207,16 +207,56 @@ return [
     |
     */
     'labels' => [
-        'categories'          => ['singular' => 'Category',           'plural' => 'Categories',           'navigation' => 'Categories'],
-        'pages'               => ['singular' => 'Page',               'plural' => 'Pages',                'navigation' => 'Pages'],
-        'posts'               => ['singular' => 'Post',               'plural' => 'Posts',                'navigation' => 'Posts'],
-        'menus'               => ['singular' => 'Menu',               'plural' => 'Menus',                'navigation' => 'Menus'],
-        'media'               => ['singular' => 'Media File',         'plural' => 'Media Files',          'navigation' => 'Media Library'],
-        'media_collections'   => ['singular' => 'Collection',         'plural' => 'Collections',          'navigation' => 'Collections'],
-        'comments'            => ['singular' => 'Comment',            'plural' => 'Comments',             'navigation' => 'Comments'],
-        'contact_submissions' => ['singular' => 'Contact Submission', 'plural' => 'Contact Submissions',  'navigation' => 'Contact Submissions'],
-        'users'               => ['singular' => 'User',               'plural' => 'Users',                'navigation' => 'Users'],
-        'site_settings'       => ['singular' => 'Site',               'plural' => 'Sites',                'navigation' => 'Site Settings'],
+        'categories' => [
+            'singular'   => 'Category',
+            'plural'     => 'Categories',
+            'navigation' => 'Categories',
+        ],
+        'pages' => [
+            'singular'   => 'Page',
+            'plural'     => 'Pages',
+            'navigation' => 'Pages',
+        ],
+        'posts' => [
+            'singular'   => 'Post',
+            'plural'     => 'Posts',
+            'navigation' => 'Posts',
+        ],
+        'menus' => [
+            'singular'   => 'Menu',
+            'plural'     => 'Menus',
+            'navigation' => 'Menus',
+        ],
+        'media' => [
+            'singular'   => 'Media File',
+            'plural'     => 'Media Files',
+            'navigation' => 'Media Library',
+        ],
+        'media_collections' => [
+            'singular'   => 'Collection',
+            'plural'     => 'Collections',
+            'navigation' => 'Collections',
+        ],
+        'comments' => [
+            'singular'   => 'Comment',
+            'plural'     => 'Comments',
+            'navigation' => 'Comments',
+        ],
+        'contact_submissions' => [
+            'singular'   => 'Contact Submission',
+            'plural'     => 'Contact Submissions',
+            'navigation' => 'Contact Submissions',
+        ],
+        'users' => [
+            'singular'   => 'User',
+            'plural'     => 'Users',
+            'navigation' => 'Users',
+        ],
+        'site_settings' => [
+            'singular'   => 'Site',
+            'plural'     => 'Sites',
+            'navigation' => 'Site Settings',
+        ],
     ],
 
     /*

--- a/packages/tallcms/cms/src/Filament/Resources/CmsCategories/CmsCategoryResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsCategories/CmsCategoryResource.php
@@ -21,8 +21,6 @@ class CmsCategoryResource extends Resource
 
     protected static ?string $model = CmsCategory::class;
 
-    protected static ?string $pluralModelLabel = 'Categories';
-
     public static function form(Schema $schema): Schema
     {
         return CmsCategoryForm::configure($schema);
@@ -59,9 +57,19 @@ class CmsCategoryResource extends Resource
         return config('tallcms.navigation.groups.content', 'Content');
     }
 
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.categories.singular', 'Category');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.categories.plural', 'Categories');
+    }
+
     public static function getNavigationLabel(): string
     {
-        return 'Categories';
+        return config('tallcms.labels.categories.navigation', 'Categories');
     }
 
     public static function getNavigationSort(): ?int

--- a/packages/tallcms/cms/src/Filament/Resources/CmsComments/CmsCommentResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsComments/CmsCommentResource.php
@@ -18,18 +18,24 @@ class CmsCommentResource extends Resource
 
     protected static ?string $model = CmsComment::class;
 
-    protected static ?string $modelLabel = 'Comment';
-
-    protected static ?string $pluralModelLabel = 'Comments';
-
     public static function getNavigationIcon(): string
     {
         return 'heroicon-o-chat-bubble-left-right';
     }
 
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.comments.singular', 'Comment');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.comments.plural', 'Comments');
+    }
+
     public static function getNavigationLabel(): string
     {
-        return 'Comments';
+        return config('tallcms.labels.comments.navigation', 'Comments');
     }
 
     public static function getNavigationGroup(): ?string

--- a/packages/tallcms/cms/src/Filament/Resources/CmsPages/CmsPageResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsPages/CmsPageResource.php
@@ -22,8 +22,6 @@ class CmsPageResource extends Resource
 
     protected static ?string $model = CmsPage::class;
 
-    protected static ?string $pluralModelLabel = 'Pages';
-
     // Title attribute enables global search automatically
     protected static ?string $recordTitleAttribute = 'title';
 
@@ -85,9 +83,19 @@ class CmsPageResource extends Resource
         return config('tallcms.navigation.groups.content', 'Content');
     }
 
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.pages.singular', 'Page');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.pages.plural', 'Pages');
+    }
+
     public static function getNavigationLabel(): string
     {
-        return 'Pages';
+        return config('tallcms.labels.pages.navigation', 'Pages');
     }
 
     public static function getNavigationSort(): ?int

--- a/packages/tallcms/cms/src/Filament/Resources/CmsPages/Schemas/CmsPageForm.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsPages/Schemas/CmsPageForm.php
@@ -70,8 +70,11 @@ class CmsPageForm
                                                 return $activeLocale === $defaultLocale;
                                             })
                                             ->maxLength(255)
-                                            ->rules(function (?CmsPage $record, $livewire) {
+                                            ->rules(function (?CmsPage $record, $livewire, Get $get) {
                                                 $rules = ['alpha_dash'];
+
+                                                // Get current parent_id from form state (works for both create and edit)
+                                                $parentId = $get('parent_id');
 
                                                 if (tallcms_i18n_enabled()) {
                                                     // Block locale codes as slugs
@@ -86,7 +89,7 @@ class CmsPageForm
                                                     // passing the id directly guarantees per-site scoping.
                                                     $siteId = $record?->site_id ?? (data_get($livewire, 'ownerSiteId') ?: null);
 
-                                                    // Unique per locale
+                                                    // Unique per locale, scoped to siblings (same parent_id)
                                                     $activeLocale = $livewire->activeLocale ?? app()->getLocale();
                                                     $rules[] = new UniqueTranslatableSlug(
                                                         table: 'tallcms_pages',
@@ -94,17 +97,22 @@ class CmsPageForm
                                                         locale: $activeLocale,
                                                         ignoreId: $record?->id,
                                                         siteId: $siteId ? (int) $siteId : null,
+                                                        parentId: $parentId ? (int) $parentId : null,
+                                                        parentIdSet: true,
                                                     );
                                                 } else {
                                                     $siteId = $record?->site_id ?? (data_get($livewire, 'ownerSiteId') ?: null);
 
-                                                    // Unique per default locale (site-aware when multisite active)
+                                                    // Unique per default locale (site-aware when multisite active),
+                                                    // scoped to siblings (same parent_id)
                                                     $rules[] = new UniqueTranslatableSlug(
                                                         table: 'tallcms_pages',
                                                         column: 'slug',
                                                         locale: app()->getLocale(),
                                                         ignoreId: $record?->id,
                                                         siteId: $siteId ? (int) $siteId : null,
+                                                        parentId: $parentId ? (int) $parentId : null,
+                                                        parentIdSet: true,
                                                     );
                                                 }
 
@@ -113,7 +121,7 @@ class CmsPageForm
                                             ->validationMessages([
                                                 'not_in' => 'This slug is reserved (matches a language code).',
                                             ])
-                                            ->helperText('Used in the URL. Keep it simple and SEO-friendly.')
+                                            ->helperText('Used as the URL segment. The full URL includes parent page slugs automatically.')
                                             ->columnSpan(1),
                                     ]),
                                 CmsRichEditor::make('content')

--- a/packages/tallcms/cms/src/Filament/Resources/CmsPosts/CmsPostResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsPosts/CmsPostResource.php
@@ -22,8 +22,6 @@ class CmsPostResource extends Resource
 
     protected static ?string $model = CmsPost::class;
 
-    protected static ?string $pluralModelLabel = 'Posts';
-
     // Title attribute enables global search automatically
     protected static ?string $recordTitleAttribute = 'title';
 
@@ -66,9 +64,19 @@ class CmsPostResource extends Resource
         return config('tallcms.navigation.groups.content', 'Content');
     }
 
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.posts.singular', 'Post');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.posts.plural', 'Posts');
+    }
+
     public static function getNavigationLabel(): string
     {
-        return 'Posts';
+        return config('tallcms.labels.posts.navigation', 'Posts');
     }
 
     public static function getNavigationSort(): ?int

--- a/packages/tallcms/cms/src/Filament/Resources/MediaCollection/MediaCollectionResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/MediaCollection/MediaCollectionResource.php
@@ -27,13 +27,25 @@ class MediaCollectionResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedFolderOpen;
 
-    protected static ?string $navigationLabel = 'Collections';
+    public static function getNavigationLabel(): string
+    {
+        return config('tallcms.labels.media_collections.navigation', 'Collections');
+    }
 
-    protected static ?string $modelLabel = 'Collection';
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.media_collections.singular', 'Collection');
+    }
 
-    protected static ?string $pluralModelLabel = 'Collections';
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.media_collections.plural', 'Collections');
+    }
 
-    protected static ?string $navigationParentItem = 'Media Library';
+    public static function getNavigationParentItem(): ?string
+    {
+        return config('tallcms.labels.media.navigation', 'Media Library');
+    }
 
     public static function getNavigationGroup(): ?string
     {

--- a/packages/tallcms/cms/src/Filament/Resources/SiteResource/SiteResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/SiteResource/SiteResource.php
@@ -22,11 +22,22 @@ class SiteResource extends Resource
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-cog-8-tooth';
 
-    protected static ?string $navigationLabel = 'Site Settings';
-
-    protected static ?string $modelLabel = 'Site';
-
     protected static ?int $navigationSort = 40;
+
+    public static function getNavigationLabel(): string
+    {
+        return config('tallcms.labels.site_settings.navigation', 'Site Settings');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.site_settings.singular', 'Site');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.site_settings.plural', 'Sites');
+    }
 
     public static function getNavigationGroup(): ?string
     {

--- a/packages/tallcms/cms/src/Filament/Resources/TallcmsContactSubmissions/TallcmsContactSubmissionResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/TallcmsContactSubmissions/TallcmsContactSubmissionResource.php
@@ -17,18 +17,24 @@ class TallcmsContactSubmissionResource extends Resource
 
     protected static ?string $model = TallcmsContactSubmission::class;
 
-    protected static ?string $modelLabel = 'Contact Submission';
-
-    protected static ?string $pluralModelLabel = 'Contact Submissions';
-
     public static function getNavigationIcon(): string
     {
         return 'heroicon-o-envelope';
     }
 
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.contact_submissions.singular', 'Contact Submission');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.contact_submissions.plural', 'Contact Submissions');
+    }
+
     public static function getNavigationLabel(): string
     {
-        return 'Contact Submissions';
+        return config('tallcms.labels.contact_submissions.navigation', 'Contact Submissions');
     }
 
     public static function getNavigationGroup(): ?string

--- a/packages/tallcms/cms/src/Filament/Resources/TallcmsMedia/TallcmsMediaResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/TallcmsMedia/TallcmsMediaResource.php
@@ -21,11 +21,20 @@ class TallcmsMediaResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
 
-    protected static ?string $navigationLabel = 'Media Library';
+    public static function getNavigationLabel(): string
+    {
+        return config('tallcms.labels.media.navigation', 'Media Library');
+    }
 
-    protected static ?string $modelLabel = 'Media File';
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.media.singular', 'Media File');
+    }
 
-    protected static ?string $pluralModelLabel = 'Media Files';
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.media.plural', 'Media Files');
+    }
 
     public static function getNavigationGroup(): ?string
     {

--- a/packages/tallcms/cms/src/Filament/Resources/TallcmsMenus/TallcmsMenuResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/TallcmsMenus/TallcmsMenuResource.php
@@ -20,11 +20,20 @@ class TallcmsMenuResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
 
-    protected static ?string $navigationLabel = 'Menus';
+    public static function getNavigationLabel(): string
+    {
+        return config('tallcms.labels.menus.navigation', 'Menus');
+    }
 
-    protected static ?string $modelLabel = 'Menu';
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.menus.singular', 'Menu');
+    }
 
-    protected static ?string $pluralModelLabel = 'Menus';
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.menus.plural', 'Menus');
+    }
 
     public static function shouldRegisterNavigation(): bool
     {

--- a/packages/tallcms/cms/src/Filament/Resources/Users/UserResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/Users/UserResource.php
@@ -19,9 +19,20 @@ class UserResource extends Resource
 {
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedUsers;
 
-    protected static ?string $modelLabel = 'User';
+    public static function getModelLabel(): string
+    {
+        return config('tallcms.labels.users.singular', 'User');
+    }
 
-    protected static ?string $pluralModelLabel = 'Users';
+    public static function getPluralModelLabel(): string
+    {
+        return config('tallcms.labels.users.plural', 'Users');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return config('tallcms.labels.users.navigation', 'Users');
+    }
 
     public static function getModel(): string
     {

--- a/packages/tallcms/cms/src/Livewire/CmsPageRenderer.php
+++ b/packages/tallcms/cms/src/Livewire/CmsPageRenderer.php
@@ -125,54 +125,71 @@ class CmsPageRenderer extends Component
      */
     protected function resolveNestedSlug(string $slug): bool
     {
-        // Split into parent and child segments
+        // Walk segments one by one, scoping each lookup to the parent found in the previous step.
+        // This handles arbitrary depth (a/b/c/d) and correctly resolves pages that store only
+        // their leaf slug — e.g. page "team" with parent_id pointing to "services".
         $segments = explode('/', $slug);
-        $childSlug = array_pop($segments);
-        $parentSlug = implode('/', $segments);
+        $parentId = null;
 
-        // Try to find parent page (use localized lookup when i18n enabled)
-        $parentPage = tallcms_i18n_enabled()
-            ? CmsPage::withLocalizedSlug($parentSlug)->published()->first()
-            : CmsPage::withSlug($parentSlug)->published()->first();
+        foreach ($segments as $i => $segment) {
+            $isLast = ($i === count($segments) - 1);
 
-        if (! $parentPage) {
-            return false;
-        }
+            // Build a query scoped to the current parent level
+            $query = tallcms_i18n_enabled()
+                ? CmsPage::withLocalizedSlug($segment)
+                : CmsPage::withSlug($segment);
 
-        // Check if parent page has a PostsBlock
-        if ($this->pageHasPostsBlock($parentPage)) {
-            // Try to find the post (use localized lookup when i18n enabled)
-            $post = tallcms_i18n_enabled()
-                ? CmsPost::withLocalizedSlug($childSlug)->with(['categories', 'author'])->first()
-                : CmsPost::withSlug($childSlug)->with(['categories', 'author'])->first();
+            $query->published();
 
-            if ($post) {
-                // Check publish status (allow drafts for authenticated users in preview)
-                $canView = $post->isPublished() ||
-                    (auth()->check() && request()->has('preview'));
-
-                if ($canView) {
-                    $this->page = $parentPage;
-                    $this->post = $post;
-                    $this->parentSlug = $parentSlug;
-                    $this->postsBlockConfig = $this->getPostsBlockConfig($parentPage);
-                    $this->renderedContent = 'POST_DETAIL';
-
-                    return true;
-                }
+            if ($parentId !== null) {
+                $query->where('parent_id', $parentId);
+            } else {
+                $query->whereNull('parent_id');
             }
-        }
 
-        // Not a post - try to find a page with the full nested slug
-        $nestedPage = tallcms_i18n_enabled()
-            ? CmsPage::withLocalizedSlug($slug)->published()->first()
-            : CmsPage::withSlug($slug)->published()->first();
+            $currentPage = $query->first();
 
-        if ($nestedPage) {
-            $this->page = $nestedPage;
-            $this->renderPageContent();
+            if (! $currentPage) {
+                // Segment didn't match a page — if this is the last segment and we found
+                // a valid parent page with a PostsBlock, treat it as a post URL.
+                if ($isLast && $parentId !== null) {
+                    $parentPage = CmsPage::find($parentId);
 
-            return true;
+                    if ($parentPage && $this->pageHasPostsBlock($parentPage)) {
+                        $post = tallcms_i18n_enabled()
+                            ? CmsPost::withLocalizedSlug($segment)->with(['categories', 'author'])->first()
+                            : CmsPost::withSlug($segment)->with(['categories', 'author'])->first();
+
+                        if ($post) {
+                            $canView = $post->isPublished() ||
+                                (auth()->check() && request()->has('preview'));
+
+                            if ($canView) {
+                                $parentSlug = implode('/', array_slice($segments, 0, $i));
+                                $this->page = $parentPage;
+                                $this->post = $post;
+                                $this->parentSlug = $parentSlug;
+                                $this->postsBlockConfig = $this->getPostsBlockConfig($parentPage);
+                                $this->renderedContent = 'POST_DETAIL';
+
+                                return true;
+                            }
+                        }
+                    }
+                }
+
+                return false;
+            }
+
+            if ($isLast) {
+                $this->page = $currentPage;
+                $this->renderPageContent();
+
+                return true;
+            }
+
+            // Intermediate segment matched — continue deeper with this page as the new parent
+            $parentId = $currentPage->id;
         }
 
         return false;

--- a/packages/tallcms/cms/src/Models/CmsPage.php
+++ b/packages/tallcms/cms/src/Models/CmsPage.php
@@ -179,6 +179,35 @@ class CmsPage extends Model implements HasRichContent
         return $this->belongsTo(CmsPage::class, 'parent_id');
     }
 
+    /**
+     * Get the full URL slug by concatenating ancestor slugs with this page's slug.
+     *
+     * A child page "team" under parent "services" returns "services/team".
+     * The leaf slug stored in the database is never modified — the full path
+     * is computed on the fly by walking the parent chain.
+     *
+     * @param  string|null  $locale  Locale for translatable slugs (null = current app locale)
+     */
+    public function getFullSlug(?string $locale = null): string
+    {
+        $slug = tallcms_i18n_enabled() && $locale
+            ? ($this->getTranslation('slug', $locale, false) ?? $this->slug)
+            : $this->slug;
+
+        if ($this->parent_id && $this->relationLoaded('parent') && $this->parent) {
+            return $this->parent->getFullSlug($locale).'/'.$slug;
+        }
+
+        if ($this->parent_id) {
+            $parent = $this->parent()->first();
+            if ($parent) {
+                return $parent->getFullSlug($locale).'/'.$slug;
+            }
+        }
+
+        return $slug;
+    }
+
     public function children(): HasMany
     {
         return $this->hasMany(CmsPage::class, 'parent_id')->orderBy('sort_order');
@@ -220,14 +249,14 @@ class CmsPage extends Model implements HasRichContent
         foreach (array_reverse($ancestors) as $ancestor) {
             $breadcrumbs[] = [
                 'name' => $ancestor->title,
-                'url' => url(tallcms_localized_url($ancestor->slug)),
+                'url' => url(tallcms_localized_url($ancestor->getFullSlug())),
             ];
         }
 
         // Add current page (last item, canonical URL without query params)
         $breadcrumbs[] = [
             'name' => $this->title,
-            'url' => url(tallcms_localized_url($this->slug)),
+            'url' => url(tallcms_localized_url($this->getFullSlug())),
         ];
 
         return $breadcrumbs;
@@ -323,6 +352,28 @@ class CmsPage extends Model implements HasRichContent
     }
 
     /**
+     * Override trait's localizedSlugExists to scope uniqueness within the same parent.
+     * Sibling pages must have unique slugs, but the same slug is allowed under different parents.
+     */
+    public function localizedSlugExists(string $slug, string $locale): bool
+    {
+        $query = static::query();
+        $this->whereJsonLocale($query, 'slug', $locale, $slug);
+
+        if ($this->exists) {
+            $query->where('id', '!=', $this->id);
+        }
+
+        if ($this->parent_id) {
+            $query->where('parent_id', $this->parent_id);
+        } else {
+            $query->whereNull('parent_id');
+        }
+
+        return $query->exists();
+    }
+
+    /**
      * Check if slug already exists (excluding current record).
      * Used when i18n is disabled, but data is still stored as JSON.
      */
@@ -340,6 +391,13 @@ class CmsPage extends Model implements HasRichContent
 
         if ($this->exists) {
             $query->where('id', '!=', $this->id);
+        }
+
+        // Scope to the same parent so sibling-unique slugs don't conflict across the tree
+        if ($this->parent_id) {
+            $query->where('parent_id', $this->parent_id);
+        } else {
+            $query->whereNull('parent_id');
         }
 
         return $query->exists();

--- a/packages/tallcms/cms/src/Rules/UniqueTranslatableSlug.php
+++ b/packages/tallcms/cms/src/Rules/UniqueTranslatableSlug.php
@@ -33,6 +33,8 @@ class UniqueTranslatableSlug implements ValidationRule
         protected string $locale,
         protected ?int $ignoreId = null,
         protected ?int $siteId = null,
+        protected ?int $parentId = null,
+        protected bool $parentIdSet = false,
     ) {
         // Normalize locale to lowercase
         $this->locale = strtolower($this->locale);
@@ -78,6 +80,16 @@ class UniqueTranslatableSlug implements ValidationRule
         // - User-owned tables (posts, categories): scope by user_id
         // - Site-owned tables (pages): scope by site_id
         $this->applyScopeFilter($query);
+
+        // For hierarchical tables (pages): scope slug uniqueness within the same parent.
+        // Siblings must have unique slugs, but the same slug is allowed under different parents.
+        if ($this->parentIdSet) {
+            if ($this->parentId !== null) {
+                $query->where('parent_id', $this->parentId);
+            } else {
+                $query->whereNull('parent_id');
+            }
+        }
 
         if ($query->exists()) {
             $fail("This slug is already used by another item in {$this->locale}.");

--- a/packages/tallcms/cms/src/Services/BlockLinkResolver.php
+++ b/packages/tallcms/cms/src/Services/BlockLinkResolver.php
@@ -27,12 +27,16 @@ class BlockLinkResolver
                             return $page->is_homepage ? '#top' : '#'.tallcms_slug_to_anchor($page->slug, $page->id);
                         }
 
-                        // Use localized URL helper which handles routes prefix and locale
-                        $slug = tallcms_i18n_enabled()
-                            ? ($page->getTranslation('slug', app()->getLocale(), false) ?? $page->getTranslation('slug', app(LocaleRegistry::class)->getDefaultLocale()))
-                            : $page->slug;
+                        if ($page->is_homepage) {
+                            return tallcms_localized_url('/');
+                        }
 
-                        return $page->is_homepage ? tallcms_localized_url('/') : tallcms_localized_url($slug);
+                        // Build full hierarchical path (parent/child) for the URL
+                        $slug = tallcms_i18n_enabled()
+                            ? $page->getFullSlug(app()->getLocale())
+                            : $page->getFullSlug();
+
+                        return tallcms_localized_url($slug);
                     }
                 }
 

--- a/packages/tallcms/cms/src/Services/MenuUrlResolver.php
+++ b/packages/tallcms/cms/src/Services/MenuUrlResolver.php
@@ -6,7 +6,6 @@ namespace TallCms\Cms\Services;
 
 use TallCms\Cms\Models\SiteSetting;
 use TallCms\Cms\Models\TallcmsMenuItem;
-use TallCms\Cms\Services\LocaleRegistry;
 
 class MenuUrlResolver
 {
@@ -36,14 +35,14 @@ class MenuUrlResolver
         }
 
         // Multi-page mode - use localized URL helper (includes routes prefix and locale)
-        // Get the localized slug for the current locale with fallback
-        $slug = tallcms_i18n_enabled()
-            ? ($page->getTranslation('slug', app()->getLocale(), false) ?? $page->getTranslation('slug', app(LocaleRegistry::class)->getDefaultLocale()))
-            : $page->slug;
-
+        // Build the full hierarchical path (parent/child) so the URL reflects the page tree.
         if ($page->is_homepage) {
             return tallcms_localized_url('/');
         }
+
+        $slug = tallcms_i18n_enabled()
+            ? $page->getFullSlug(app()->getLocale())
+            : $page->getFullSlug();
 
         return tallcms_localized_url($slug);
     }

--- a/packages/tallcms/cms/src/Services/SitemapService.php
+++ b/packages/tallcms/cms/src/Services/SitemapService.php
@@ -155,10 +155,11 @@ class SitemapService
             $baseUrl = tallcms_base_url();
 
             return CmsPage::published()
+                ->with('parent.parent.parent')
                 ->orderBy('updated_at', 'desc')
                 ->get()
                 ->map(function ($page) use ($baseUrl, $prefix) {
-                    $slug = $page->is_homepage ? '' : '/'.$page->slug;
+                    $slug = $page->is_homepage ? '' : '/'.$page->getFullSlug();
 
                     return [
                         'loc' => $baseUrl.$prefix.$slug,

--- a/packages/tallcms/cms/src/Services/SitemapService.php
+++ b/packages/tallcms/cms/src/Services/SitemapService.php
@@ -154,20 +154,23 @@ class SitemapService
             $prefix = self::getPrefix();
             $baseUrl = tallcms_base_url();
 
-            return CmsPage::published()
-                ->with('parent.parent.parent')
-                ->orderBy('updated_at', 'desc')
-                ->get()
-                ->map(function ($page) use ($baseUrl, $prefix) {
-                    $slug = $page->is_homepage ? '' : '/'.$page->getFullSlug();
+            // Load all pages in one query, then wire parent relations in PHP.
+            // This handles arbitrary hierarchy depth with zero N+1 queries.
+            $pages = CmsPage::published()->orderBy('updated_at', 'desc')->get()->keyBy('id');
+            $pages->each(function ($page) use ($pages) {
+                $page->setRelation('parent', $pages->get($page->parent_id));
+            });
 
-                    return [
-                        'loc' => $baseUrl.$prefix.$slug,
-                        'lastmod' => $page->updated_at?->toIso8601String(),
-                        'changefreq' => $page->is_homepage ? 'daily' : 'weekly',
-                        'priority' => $page->is_homepage ? '1.0' : '0.8',
-                    ];
-                });
+            return $pages->values()->map(function ($page) use ($baseUrl, $prefix) {
+                $slug = $page->is_homepage ? '' : '/'.$page->getFullSlug();
+
+                return [
+                    'loc' => $baseUrl.$prefix.$slug,
+                    'lastmod' => $page->updated_at?->toIso8601String(),
+                    'changefreq' => $page->is_homepage ? 'daily' : 'weekly',
+                    'priority' => $page->is_homepage ? '1.0' : '0.8',
+                ];
+            });
         });
     }
 

--- a/packages/tallcms/cms/src/TallCmsPlugin.php
+++ b/packages/tallcms/cms/src/TallCmsPlugin.php
@@ -7,6 +7,7 @@ namespace TallCms\Cms;
 use BezhanSalleh\FilamentShield\FilamentShieldPlugin;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
 use LaraZeus\SpatieTranslatable\SpatieTranslatablePlugin;
 use TallCms\Cms\Filament\Pages\ApiTokens;
@@ -72,6 +73,9 @@ class TallCmsPlugin implements Plugin
 
     protected ?string $shieldNavigationGroup = null; // Set dynamically from config
 
+    /** @var array<string, array{singular?: string, plural?: string, navigation?: string}> */
+    protected array $labelOverrides = [];
+
     public static function make(): static
     {
         return app(static::class);
@@ -92,6 +96,12 @@ class TallCmsPlugin implements Plugin
 
     public function register(Panel $panel): void
     {
+        foreach ($this->labelOverrides as $key => $labels) {
+            foreach ($labels as $type => $value) {
+                Config::set("tallcms.labels.{$key}.{$type}", $value);
+            }
+        }
+
         $panel
             ->resources($this->getResources())
             ->pages($this->getPages())
@@ -545,6 +555,108 @@ class TallCmsPlugin implements Plugin
     public function shieldNavigationGroup(?string $group): static
     {
         $this->shieldNavigationGroup = $group;
+
+        return $this;
+    }
+
+    /**
+     * Rename the Categories resource labels.
+     *
+     * Example: ->categoryLabel('Tags', 'Tag')
+     */
+    public function categoryLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('categories', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Pages resource labels.
+     *
+     * Example: ->pageLabel('Website Pages', 'Website Page')
+     */
+    public function pageLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('pages', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Posts resource labels.
+     *
+     * Example: ->postLabel('Articles', 'Article')
+     */
+    public function postLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('posts', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Menus resource labels.
+     */
+    public function menuLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('menus', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Media resource labels.
+     */
+    public function mediaLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('media', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Media Collections resource labels.
+     */
+    public function mediaCollectionLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('media_collections', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Comments resource labels.
+     */
+    public function commentLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('comments', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Contact Submissions resource labels.
+     */
+    public function contactSubmissionLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('contact_submissions', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Users resource labels.
+     */
+    public function userLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('users', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Rename the Site Settings resource labels.
+     */
+    public function siteSettingsLabel(string $plural, ?string $singular = null, ?string $navigation = null): static
+    {
+        return $this->setResourceLabels('site_settings', $plural, $singular, $navigation);
+    }
+
+    /**
+     * Store label overrides for a resource key.
+     * $navigation defaults to $plural when not provided.
+     * $singular defaults to $plural when not provided.
+     */
+    protected function setResourceLabels(string $key, string $plural, ?string $singular, ?string $navigation): static
+    {
+        $this->labelOverrides[$key] = [
+            'plural' => $plural,
+            'singular' => $singular ?? $plural,
+            'navigation' => $navigation ?? $plural,
+        ];
 
         return $this;
     }


### PR DESCRIPTION
Build hierarchical page URLs from parent slug chain

Child pages now generate full-path URLs (e.g. /services/team) instead of
leaf-only slugs (/team). getFullSlug() walks the parent chain; all URL
generation points (menus, sitemap, block links, breadcrumbs) and the
frontend page resolver now use the full path. Slug uniqueness is scoped
to siblings (same parent_id) so the same slug is allowed under different
parents.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>