### PR TITLE
Use relationship() for author dropdown and read category labels from config

### DIFF
--- a/packages/tallcms/cms/src/Filament/Resources/CmsCategories/Schemas/CmsCategoryForm.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsCategories/Schemas/CmsCategoryForm.php
@@ -77,7 +77,7 @@ class CmsCategoryForm
                     ->helperText('Used in the URL. Only letters, numbers, hyphens and underscores allowed.'),
 
                 Select::make('parent_id')
-                    ->label('Parent Category')
+                    ->label('Parent '.config('tallcms.labels.categories.singular', 'Category'))
                     ->options(function () {
                         $query = CmsCategory::query()->whereNull('parent_id');
                         if (auth()->check() && ! auth()->user()->hasRole('super_admin')
@@ -91,7 +91,7 @@ class CmsCategoryForm
                     ->nullable(),
 
                 ColorPicker::make('color')
-                    ->label('Category Color')
+                    ->label(config('tallcms.labels.categories.singular', 'Category').' Color')
                     ->nullable()
                     ->helperText('Optional color for visual organization'),
 

--- a/packages/tallcms/cms/src/Filament/Resources/CmsPages/Schemas/CmsPageForm.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsPages/Schemas/CmsPageForm.php
@@ -15,6 +15,8 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Tabs;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Schema as DbSchema;
 use Illuminate\Support\Str;
 use TallCms\Cms\Enums\ContentStatus;
@@ -195,14 +197,16 @@ class CmsPageForm
 
                                         Select::make('author_id')
                                             ->label('Author')
-                                            ->options(function () {
-                                                $userModel = config('tallcms.plugin_mode.user_model', 'App\\Models\\User');
-
-                                                return $userModel::query()->pluck('name', 'id');
-                                            })
+                                            ->relationship(
+                                                name: 'author',
+                                                titleAttribute: 'name',
+                                                modifyQueryUsing: fn (Builder $query) => $query->orderBy('name'),
+                                            )
+                                            ->getOptionLabelFromRecordUsing(fn (Model $record): string => $record->name)
+                                            ->searchable()
+                                            ->preload()
                                             ->default(auth()->id())
-                                            ->nullable()
-                                            ->searchable(),
+                                            ->nullable(),
 
                                         Toggle::make('is_homepage')
                                             ->label('Set as Homepage')

--- a/packages/tallcms/cms/src/Filament/Resources/CmsPosts/Schemas/CmsPostForm.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsPosts/Schemas/CmsPostForm.php
@@ -14,6 +14,8 @@ use Filament\Schemas\Components\Livewire;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Tabs;
 use Filament\Schemas\Schema;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Schema as DbSchema;
 use Illuminate\Support\Str;
 use TallCms\Cms\Enums\ContentStatus;
@@ -180,11 +182,14 @@ class CmsPostForm
 
                                         Select::make('author_id')
                                             ->label('Author')
-                                            ->options(function () {
-                                                $userModel = config('tallcms.plugin_mode.user_model', 'App\\Models\\User');
-
-                                                return $userModel::query()->pluck('name', 'id');
-                                            })
+                                            ->relationship(
+                                                name: 'author',
+                                                titleAttribute: 'name',
+                                                modifyQueryUsing: fn (Builder $query) => $query->orderBy('name'),
+                                            )
+                                            ->getOptionLabelFromRecordUsing(fn (Model $record): string => $record->name)
+                                            ->searchable()
+                                            ->preload()
                                             ->default(auth()->id())
                                             ->required(),
 
@@ -193,7 +198,7 @@ class CmsPostForm
                                             ->helperText('Featured posts appear prominently'),
                                     ]),
 
-                                Section::make('Categories')
+                                Section::make(config('tallcms.labels.categories.plural', 'Categories'))
                                     ->schema([
                                         Select::make('categories')
                                             ->multiple()
@@ -245,7 +250,7 @@ class CmsPostForm
                                                 Textarea::make('description')
                                                     ->rows(2),
                                             ])
-                                            ->helperText('Select existing categories or create new ones for this post'),
+                                            ->helperText('Select existing '.config('tallcms.labels.categories.plural', 'categories').' or create new ones for this post'),
                                     ]),
                             ]),
 

--- a/packages/tallcms/cms/src/Filament/Resources/CmsPosts/Tables/CmsPostsTable.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsPosts/Tables/CmsPostsTable.php
@@ -48,7 +48,7 @@ class CmsPostsTable
                     ->label('Featured'),
 
                 TagsColumn::make('categories.name')
-                    ->label('Categories')
+                    ->label(config('tallcms.labels.categories.plural', 'Categories'))
                     ->limit(3),
 
                 TextColumn::make('author.name')
@@ -88,6 +88,7 @@ class CmsPostsTable
                     ]),
 
                 SelectFilter::make('categories')
+                    ->label(config('tallcms.labels.categories.plural', 'Categories'))
                     ->relationship('categories', 'name')
                     ->multiple(),
 

--- a/packages/tallcms/cms/tests/Feature/CategoryLabelPropagationTest.php
+++ b/packages/tallcms/cms/tests/Feature/CategoryLabelPropagationTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace TallCms\Cms\Tests\Feature;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use TallCms\Cms\Tests\TestCase;
+
+/**
+ * PR #60 regression guard — category labels inside CmsPostForm, CmsPostsTable,
+ * and CmsCategoryForm must read from `tallcms.labels.categories.*` so a rename
+ * (e.g. "Categories" → "Tags") propagates into form section headings, helper
+ * text, table columns, and filter labels — not only into the resource-level
+ * labels covered by ResourceLabelOverrideTest.
+ *
+ * These assertions intentionally operate on source strings rather than
+ * mounting the Filament schema. The alternative — instantiating a full
+ * Schema with a stub Livewire component — costs more setup than the value
+ * added for a defensive-consistency change. Source assertions catch the
+ * regression we actually care about: someone re-hardcoding "Category" /
+ * "Categories" in these exact spots.
+ */
+class CategoryLabelPropagationTest extends TestCase
+{
+    #[DataProvider('configReadCallsites')]
+    public function test_source_file_reads_category_label_from_config(
+        string $relativePath,
+        string $expectedConfigCall,
+        string $context,
+    ): void {
+        $source = file_get_contents(self::packagePath($relativePath));
+
+        $this->assertStringContainsString(
+            $expectedConfigCall,
+            $source,
+            "{$context} must read the category label from config so the label "
+            .'override API (PR #57) covers renames deep in forms and tables, '
+            .'not only at the resource level.',
+        );
+    }
+
+    public static function configReadCallsites(): array
+    {
+        return [
+            'CmsPostForm categories section heading' => [
+                'src/Filament/Resources/CmsPosts/Schemas/CmsPostForm.php',
+                "config('tallcms.labels.categories.plural'",
+                'The Categories section heading in CmsPostForm',
+            ],
+            'CmsPostsTable categories column' => [
+                'src/Filament/Resources/CmsPosts/Tables/CmsPostsTable.php',
+                "config('tallcms.labels.categories.plural'",
+                'The categories column label in CmsPostsTable',
+            ],
+            'CmsCategoryForm parent field' => [
+                'src/Filament/Resources/CmsCategories/Schemas/CmsCategoryForm.php',
+                "config('tallcms.labels.categories.singular'",
+                'The Parent field label in CmsCategoryForm',
+            ],
+        ];
+    }
+
+    public function test_cms_post_form_does_not_hardcode_categories_section_heading(): void
+    {
+        // Belt-and-braces: assert the specific hardcoded strings we replaced
+        // are NOT present, so a partial revert that restores the literal would
+        // fail this test even if the config call is kept elsewhere.
+        $source = file_get_contents(self::packagePath(
+            'src/Filament/Resources/CmsPosts/Schemas/CmsPostForm.php'
+        ));
+
+        $this->assertStringNotContainsString(
+            "Section::make('Categories')",
+            $source,
+            'CmsPostForm must not hardcode the Categories section heading — '
+            .'use config(\'tallcms.labels.categories.plural\', ...) instead.',
+        );
+    }
+
+    public function test_author_dropdown_uses_relationship_not_plucked_options(): void
+    {
+        // The PR #60 change switched author dropdowns from
+        //   ->options(fn () => $userModel::query()->pluck('name', 'id'))
+        // to
+        //   ->relationship(name: 'author', titleAttribute: 'name', ...)
+        //      ->getOptionLabelFromRecordUsing(fn (Model $record) => $record->name)
+        // so host-app Users with first_name/last_name + a `name` accessor
+        // get the correct label without a form override.
+        foreach (['CmsPostForm', 'CmsPageForm'] as $form) {
+            $source = file_get_contents(self::packagePath(
+                "src/Filament/Resources/".($form === 'CmsPostForm' ? 'CmsPosts' : 'CmsPages')
+                ."/Schemas/{$form}.php"
+            ));
+
+            // Positive: must call the record-aware label resolver so a
+            // hydrated User flows through its name accessor.
+            $this->assertStringContainsString(
+                'getOptionLabelFromRecordUsing',
+                $source,
+                "{$form} must use ->getOptionLabelFromRecordUsing() on the "
+                .'author dropdown so a hydrated User model flows through any '
+                .'accessor (e.g. first_name + last_name => name).',
+            );
+
+            // Positive: must bind the author dropdown to the relationship,
+            // not a statically-plucked options array.
+            $this->assertMatchesRegularExpression(
+                "/->relationship\(\s*name:\s*'author'/",
+                $source,
+                "{$form} must bind the author dropdown to the `author` "
+                .'relationship with ->relationship(name: \'author\', ...) '
+                .'so Filament hydrates User records for the label callback.',
+            );
+        }
+    }
+
+    protected static function packagePath(string $relative): string
+    {
+        return dirname(__DIR__, 2).'/'.$relative;
+    }
+}


### PR DESCRIPTION
Use relationship() for author dropdown and read category labels from config

Author Select on CmsPostForm and CmsPageForm switched from ->options(fn () => $model::query()->pluck('name', 'id')) to ->relationship() + ->getOptionLabelFromRecordUsing(), so the label closure receives a hydrated model instance and any name accessor on the app's User model is honoured automatically — no form overwrite needed for apps with first_name/last_name columns.

Category labels in CmsPostForm (section heading, helper text) and CmsPostsTable (column, filter) now read from
config('tallcms.labels.categories.*') instead of hardcoding "Categories", consistent with the label override API on TallCmsPlugin. Same fix applied to CmsCategoryForm for the Parent and Color field labels.