### PR TITLE
Warn during tallcms:install when Vite manifest is missing

### DIFF
--- a/packages/tallcms/cms/src/Console/Commands/TallCmsInstall.php
+++ b/packages/tallcms/cms/src/Console/Commands/TallCmsInstall.php
@@ -441,6 +441,13 @@ class TallCmsInstall extends Command
         $this->components->info('TallCMS installed successfully!');
         $this->newLine();
 
+        // Frontend assets check — Filament admin pages reference @vite() in
+        // the host app's base layout, so an unbuilt manifest crashes every
+        // admin page render with Illuminate\Foundation\ViteManifestNotFoundException.
+        // Surface this proactively so plugin-mode adopters don't hit it on
+        // the first click into the admin.
+        $this->checkFrontendAssets();
+
         // Short reminder when --skip-checks was used (plugin validation was skipped)
         if ($this->option('skip-checks')) {
             $this->components->warn('Reminder: Ensure TallCmsPlugin::make() is registered in your panel provider.');
@@ -493,6 +500,34 @@ class TallCmsInstall extends Command
 
             $this->components->info('Thank you! Your support means a lot to us.');
         }
+    }
+
+    /**
+     * Warn the user if the host app's Vite manifest hasn't been built yet.
+     *
+     * Filament admin layouts call @vite() on the host's resources/css/app.css
+     * etc., so without a built manifest every admin page returns
+     * `Illuminate\Foundation\ViteManifestNotFoundException`. This is a
+     * generic Laravel/Filament friction point, but plugin-mode adopters
+     * land on it immediately after `tallcms:install` because the next
+     * thing they do is open the admin.
+     */
+    protected function checkFrontendAssets(): void
+    {
+        if (file_exists(public_path('build/manifest.json'))) {
+            return;
+        }
+
+        $this->components->warn('Frontend assets are not built yet.');
+        $this->line('  Filament admin pages reference <fg=cyan>@vite()</> in the host app\'s base layout —');
+        $this->line('  without a built manifest, every admin page returns a 500.');
+        $this->newLine();
+        $this->line('  Build before opening the admin:');
+        $this->line('    <fg=green>npm install && npm run build</>');
+        $this->newLine();
+        $this->line('  Or for development with hot reload:');
+        $this->line('    <fg=green>npm run dev</>');
+        $this->newLine();
     }
 
     /**

--- a/packages/tallcms/cms/tests/Feature/InstallCommandFrontendAssetsCheckTest.php
+++ b/packages/tallcms/cms/tests/Feature/InstallCommandFrontendAssetsCheckTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace TallCms\Cms\Tests\Feature;
+
+use Illuminate\Console\OutputStyle;
+use Illuminate\Console\View\Components\Factory;
+use ReflectionMethod;
+use ReflectionProperty;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use TallCms\Cms\Console\Commands\TallCmsInstall;
+use TallCms\Cms\Tests\TestCase;
+
+/**
+ * Plugin-mode adopters running `tallcms:install` would previously land
+ * on a `Illuminate\Foundation\ViteManifestNotFoundException` the moment
+ * they opened the admin, because the host app's Vite manifest hadn't
+ * been built. This test locks in the proactive warning emitted at the
+ * end of the install command so the friction surfaces in the install
+ * output instead of as a runtime 500.
+ */
+class InstallCommandFrontendAssetsCheckTest extends TestCase
+{
+    public function test_warns_when_vite_manifest_is_missing(): void
+    {
+        $manifest = public_path('build/manifest.json');
+        $this->ensureManifestAbsent($manifest);
+
+        $output = $this->invokeCheck();
+
+        $this->assertStringContainsString('Frontend assets are not built yet', $output);
+        $this->assertStringContainsString('npm install && npm run build', $output);
+        $this->assertStringContainsString('npm run dev', $output);
+    }
+
+    public function test_silent_when_vite_manifest_is_present(): void
+    {
+        $manifest = public_path('build/manifest.json');
+        $this->ensureManifestPresent($manifest);
+
+        try {
+            $output = $this->invokeCheck();
+
+            $this->assertStringNotContainsString('Frontend assets are not built yet', $output,
+                'When the manifest exists, the install command must stay silent — '
+                .'no warning, no spurious npm guidance in the completion output.');
+        } finally {
+            $this->ensureManifestAbsent($manifest);
+        }
+    }
+
+    /**
+     * Instantiate the command in isolation, wire up an output buffer, and
+     * invoke the protected check directly via reflection. Avoids running
+     * the rest of the install pipeline (publishes, migrations, theme
+     * activation, vendor:publish side effects) which aren't relevant here.
+     */
+    protected function invokeCheck(): string
+    {
+        $command = new TallCmsInstall;
+        $command->setLaravel($this->app);
+
+        $buffer = new BufferedOutput;
+        $outputStyle = new OutputStyle(new StringInput(''), $buffer);
+        $command->setOutput($outputStyle);
+
+        // The components factory is normally wired up in Command::run(); we
+        // skip that path so we can call the protected check in isolation,
+        // which means we wire the factory up by hand.
+        $componentsProperty = new ReflectionProperty($command, 'components');
+        $componentsProperty->setAccessible(true);
+        $componentsProperty->setValue($command, new Factory($outputStyle));
+
+        $method = new ReflectionMethod($command, 'checkFrontendAssets');
+        $method->setAccessible(true);
+        $method->invoke($command);
+
+        return $buffer->fetch();
+    }
+
+    protected function ensureManifestAbsent(string $manifest): void
+    {
+        if (file_exists($manifest)) {
+            @unlink($manifest);
+        }
+    }
+
+    protected function ensureManifestPresent(string $manifest): void
+    {
+        if (! is_dir(dirname($manifest))) {
+            mkdir(dirname($manifest), 0755, true);
+        }
+        file_put_contents($manifest, '{}');
+    }
+}


### PR DESCRIPTION
## Why

Plugin-mode adopters running \`php artisan tallcms:install\` land on \`Illuminate\Foundation\ViteManifestNotFoundException\` the moment they open the admin, because the host app's Vite manifest hasn't been built. This is generic Filament behaviour — admin layouts call \`@vite()\` on the host's \`resources/css/app.css\` — but for someone evaluating TallCMS for the first time it surfaces as a 500 right after install.

Surfacing it in the install output instead of as a runtime error.

## Change

At the end of \`TallCmsInstall::showCompletionMessage()\`, check for \`public/build/manifest.json\`. If absent, emit a warning with the exact npm commands:

\`\`\`
WARNING  Frontend assets are not built yet.
  Filament admin pages reference @vite() in the host app's base layout —
  without a built manifest, every admin page returns a 500.

  Build before opening the admin:
    npm install && npm run build

  Or for development with hot reload:
    npm run dev
\`\`\`

Silent if the manifest exists.

## Test plan

- [x] \`tests/Feature/InstallCommandFrontendAssetsCheckTest.php\` covers both states (manifest absent → warning emitted; manifest present → silent)
- [x] Full package suite still green (334/334)
- [x] Manually verified locally: warning appears in fresh \`composer require tallcms/cms && php artisan tallcms:install\` flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)