### PR TITLE
Clear stale caches at end of tallcms:install

### DIFF
--- a/packages/tallcms/cms/src/Console/Commands/TallCmsInstall.php
+++ b/packages/tallcms/cms/src/Console/Commands/TallCmsInstall.php
@@ -94,6 +94,14 @@ class TallCmsInstall extends Command
             $this->runSetup();
         }
 
+        // Step 9: Clear stale caches before the user opens the admin.
+        // The Plugin Manager (and other parts of TallCMS / Filament) cache
+        // plugin and config metadata, which can include serialized objects
+        // (Carbon dates, etc). After a fresh install or upgrade, leftover
+        // entries from a prior state can deserialize as __PHP_Incomplete_Class
+        // and TypeError on the first admin page render.
+        $this->clearCaches();
+
         // Show completion message
         $this->showCompletionMessage();
 
@@ -411,6 +419,42 @@ class TallCmsInstall extends Command
     {
         $this->components->task('Running database migrations', function () {
             $this->callSilently('migrate', ['--force' => true]);
+
+            return true;
+        });
+    }
+
+    /**
+     * Clear the application and config caches. Runs after the install
+     * pipeline so any stale serialized state from a prior install (e.g.
+     * Plugin Manager metadata containing Carbon dates) doesn't deserialize
+     * as __PHP_Incomplete_Class on the first admin page load.
+     *
+     * Targeted clears rather than `optimize:clear` because the latter
+     * chains subcommands (e.g. `icons:clear`) that may not be registered
+     * in every host environment. cache:clear + config:clear cover the
+     * actual reported failure mode.
+     */
+    protected function clearCaches(): void
+    {
+        $this->components->task('Clearing stale caches', function () {
+            // Artisan::call resolves through the container, so this works
+            // both when the install command runs normally and when it's
+            // instantiated in isolation (the regression test path).
+            // Each clear is wrapped so a misconfigured driver doesn't
+            // abort the install — degrade silently and let the user
+            // re-clear manually if needed.
+            try {
+                \Illuminate\Support\Facades\Artisan::call('cache:clear');
+            } catch (\Throwable) {
+                // ignore
+            }
+
+            try {
+                \Illuminate\Support\Facades\Artisan::call('config:clear');
+            } catch (\Throwable) {
+                // ignore
+            }
 
             return true;
         });

--- a/packages/tallcms/cms/tests/Feature/InstallCommandClearCachesTest.php
+++ b/packages/tallcms/cms/tests/Feature/InstallCommandClearCachesTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace TallCms\Cms\Tests\Feature;
+
+use Illuminate\Console\OutputStyle;
+use Illuminate\Console\View\Components\Factory;
+use ReflectionMethod;
+use ReflectionProperty;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use TallCms\Cms\Console\Commands\TallCmsInstall;
+use TallCms\Cms\Tests\TestCase;
+
+/**
+ * Stale Plugin Manager / config cache entries from a prior install can
+ * deserialize as __PHP_Incomplete_Class on the first admin page render
+ * after a fresh `tallcms:install`, surfacing as a TypeError deep inside
+ * Carbon. The install command now runs `optimize:clear` at the end of
+ * the pipeline to prevent this. This test pins the user-facing output
+ * so the step doesn't silently get removed in a refactor.
+ */
+class InstallCommandClearCachesTest extends TestCase
+{
+    public function test_clear_caches_step_emits_task_message(): void
+    {
+        $output = $this->invokeClearCaches();
+
+        $this->assertStringContainsString('Clearing stale caches', $output,
+            'The cache-clearing step must announce itself in the install '
+            .'output so users (and CI logs) can see it ran.');
+    }
+
+    /**
+     * Instantiate the command in isolation and call the protected
+     * clearCaches step directly. Mirrors the pattern used by
+     * InstallCommandFrontendAssetsCheckTest.
+     */
+    protected function invokeClearCaches(): string
+    {
+        $command = new TallCmsInstall;
+        $command->setLaravel($this->app);
+
+        $buffer = new BufferedOutput;
+        $outputStyle = new OutputStyle(new StringInput(''), $buffer);
+        $command->setOutput($outputStyle);
+
+        $componentsProperty = new ReflectionProperty($command, 'components');
+        $componentsProperty->setAccessible(true);
+        $componentsProperty->setValue($command, new Factory($outputStyle));
+
+        $method = new ReflectionMethod($command, 'clearCaches');
+        $method->setAccessible(true);
+        $method->invoke($command);
+
+        return $buffer->fetch();
+    }
+}


### PR DESCRIPTION
## Why

Surfaced during a fresh plugin-mode install test: opening the Plugin Manager page after \`tallcms:install\` would crash with:

\`\`\`
TypeError: Carbon\CarbonImmutable::resolveCarbon(): Argument #1 (\$date) must be of type DateTimeInterface|string|null, __PHP_Incomplete_Class given
\`\`\`

Root cause: Plugin Manager (and other parts of TallCMS / Filament) caches metadata that includes serialized objects — Carbon dates among them. After a fresh install or upgrade, leftover cache entries from a prior state can deserialize as \`__PHP_Incomplete_Class\` because the class context isn't loaded the same way it was at serialization time. The user-facing fix is just \`php artisan cache:clear\` — but expecting that as a manual step right after install is a poor first-run experience.

## Change

Adds a \`clearCaches\` step at the end of the \`tallcms:install\` pipeline (between \`tallcms:setup\` and the completion message). Uses \`Artisan::call('cache:clear')\` + \`Artisan::call('config:clear')\` rather than \`optimize:clear\` — the latter chains \`icons:clear\` which isn't always registered (broke in the test environment). Each clear is wrapped in try/catch so a misconfigured cache driver doesn't abort the install.

\`\`\`
Clearing stale caches ............................. DONE
\`\`\`

## Test plan

- [x] \`tests/Feature/InstallCommandClearCachesTest.php\` pins the user-facing task message so the step doesn't get silently removed in a refactor
- [x] Full package suite: 342/342 (was 339)
- [x] Reproduces the regression locally — Plugin Manager TypeError went away after a single \`cache:clear\` in user testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)