### PR TITLE
Add configurable media disk via TALLCMS_MEDIA_DISK

### DIFF
--- a/config/tallcms.php
+++ b/config/tallcms.php
@@ -26,6 +26,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Media Library
+    |--------------------------------------------------------------------------
+    |
+    | Set 'disk' to any filesystem disk defined in config/filesystems.php.
+    | Leave null to let TallCMS auto-detect: 's3' when S3 is configured,
+    | otherwise 'public'.
+    |
+    | Example: TALLCMS_MEDIA_DISK=my-s3-bucket
+    |
+    */
+    'media' => [
+        'disk' => env('TALLCMS_MEDIA_DISK'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Publishing Workflow
     |--------------------------------------------------------------------------
     |

--- a/config/tallcms.php
+++ b/config/tallcms.php
@@ -26,22 +26,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Media Library
-    |--------------------------------------------------------------------------
-    |
-    | Set 'disk' to any filesystem disk defined in config/filesystems.php.
-    | Leave null to let TallCMS auto-detect: 's3' when S3 is configured,
-    | otherwise 'public'.
-    |
-    | Example: TALLCMS_MEDIA_DISK=my-s3-bucket
-    |
-    */
-    'media' => [
-        'disk' => env('TALLCMS_MEDIA_DISK'),
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
     | Publishing Workflow
     |--------------------------------------------------------------------------
     |

--- a/docs/gs-installation.md
+++ b/docs/gs-installation.md
@@ -363,7 +363,7 @@ TallCMS supports S3-compatible cloud storage for media uploads.
 
 ### Configuration
 
-Add to your `.env` file:
+**Option A — use S3 as the default filesystem** (simplest):
 
 ```env
 # Storage credentials
@@ -378,6 +378,32 @@ FILESYSTEM_DISK=s3
 # For non-AWS providers, add endpoint:
 AWS_ENDPOINT=https://nyc3.digitaloceanspaces.com
 ```
+
+TallCMS detects `FILESYSTEM_DISK=s3` and routes all media uploads to S3 automatically.
+
+**Option B — dedicated media disk** (when your app's default filesystem stays local):
+
+Define a named disk in `config/filesystems.php`:
+
+```php
+'cms-media' => [
+    'driver'     => 's3',
+    'key'        => env('CMS_MEDIA_KEY'),
+    'secret'     => env('CMS_MEDIA_SECRET'),
+    'region'     => env('CMS_MEDIA_REGION', 'us-east-1'),
+    'bucket'     => env('CMS_MEDIA_BUCKET'),
+    'url'        => env('CMS_MEDIA_URL'),      // optional CDN URL
+    'visibility' => 'public',
+],
+```
+
+Then tell TallCMS to use it:
+
+```env
+TALLCMS_MEDIA_DISK=cms-media
+```
+
+`TALLCMS_MEDIA_DISK` takes priority over the auto-detection. It accepts any disk name registered in `config/filesystems.php`.
 
 ### Provider Examples
 

--- a/docs/site-media.md
+++ b/docs/site-media.md
@@ -265,28 +265,104 @@ Posts and pages can have featured images:
 
 ---
 
-## Cloud Storage
+## File Storage
 
-TallCMS can store media in cloud storage instead of locally.
+### How TallCMS Stores Files
 
-### Supported Providers
+By default, TallCMS saves uploaded files to your server's local disk at `storage/app/public/media`, served via a symlink at `public/storage`. This works out of the box with no configuration required.
 
+Each media record stores the disk name it was uploaded to, so files are always read from the correct location regardless of future configuration changes.
+
+### Switching to Cloud Storage
+
+TallCMS automatically uses S3-compatible storage when it detects a valid S3 configuration in your `.env`. No other change is needed:
+
+```env
+# Your storage credentials
+AWS_ACCESS_KEY_ID=your-access-key
+AWS_SECRET_ACCESS_KEY=your-secret-key
+AWS_DEFAULT_REGION=us-east-1
+AWS_BUCKET=your-bucket-name
+
+# Tell Laravel (and TallCMS) to use S3
+FILESYSTEM_DISK=s3
+```
+
+Once set, all new uploads go to S3. Existing local files are not migrated automatically.
+
+**Supported providers:**
 - Amazon S3
 - DigitalOcean Spaces
 - Cloudflare R2
+- Backblaze B2
+- Wasabi
+- MinIO (self-hosted)
 - Any S3-compatible service
 
-### Benefits
+### Using a Dedicated Media Disk
 
-- **Scalability**: No local disk limits
-- **Performance**: CDN delivery for faster loading
-- **Reliability**: Cloud provider handles redundancy
+If you want TallCMS media on a separate disk — without changing your app's default filesystem — define a named disk in `config/filesystems.php` and point TallCMS at it with `TALLCMS_MEDIA_DISK`.
 
-### Setup
+**Step 1** — add the disk to `config/filesystems.php`:
 
-Cloud storage is configured during installation or in your `.env` file. See the [installation guide](installation) for details.
+```php
+'disks' => [
+    // ... your existing disks ...
 
-Image optimization works with cloud storage—variants are generated locally and uploaded to your configured storage.
+    'cms-media' => [
+        'driver' => 's3',
+        'key'    => env('CMS_MEDIA_KEY'),
+        'secret' => env('CMS_MEDIA_SECRET'),
+        'region' => env('CMS_MEDIA_REGION', 'us-east-1'),
+        'bucket' => env('CMS_MEDIA_BUCKET'),
+        'url'    => env('CMS_MEDIA_URL'),         // optional CDN URL
+        'visibility' => 'public',
+    ],
+],
+```
+
+**Step 2** — set the disk name in `.env`:
+
+```env
+TALLCMS_MEDIA_DISK=cms-media
+```
+
+`TALLCMS_MEDIA_DISK` takes priority over the auto-detection logic. Any disk registered in `config/filesystems.php` works — local, S3, or any custom driver.
+
+### Provider Quick-Reference
+
+**DigitalOcean Spaces:**
+```env
+AWS_ACCESS_KEY_ID=your-spaces-key
+AWS_SECRET_ACCESS_KEY=your-spaces-secret
+AWS_DEFAULT_REGION=nyc3
+AWS_BUCKET=my-space-name
+AWS_ENDPOINT=https://nyc3.digitaloceanspaces.com
+FILESYSTEM_DISK=s3
+```
+
+**Cloudflare R2:**
+```env
+AWS_ACCESS_KEY_ID=your-r2-access-key
+AWS_SECRET_ACCESS_KEY=your-r2-secret-key
+AWS_DEFAULT_REGION=auto
+AWS_BUCKET=my-bucket
+AWS_ENDPOINT=https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com
+FILESYSTEM_DISK=s3
+```
+
+**MinIO (self-hosted):**
+```env
+AWS_ACCESS_KEY_ID=minioadmin
+AWS_SECRET_ACCESS_KEY=minioadmin
+AWS_DEFAULT_REGION=us-east-1
+AWS_BUCKET=my-bucket
+AWS_ENDPOINT=http://localhost:9000
+AWS_USE_PATH_STYLE_ENDPOINT=true
+FILESYSTEM_DISK=s3
+```
+
+> Image optimization works with all storage backends — variants are generated locally and uploaded to your configured disk.
 
 ---
 
@@ -303,6 +379,12 @@ Verify the collection contains images (not videos/documents). Check that images 
 
 **"Optimization not running"**
 Image optimization runs in the background queue. Ensure your queue worker is running: `php artisan queue:work`
+
+**"Images uploaded to the wrong disk after changing storage config"**
+Each media record stores the disk it was uploaded to. Changing `TALLCMS_MEDIA_DISK` or `FILESYSTEM_DISK` only affects new uploads — existing records still reference their original disk. To move existing files, re-upload them after updating the configuration.
+
+**"Uploaded file is inaccessible after setting TALLCMS_MEDIA_DISK"**
+The disk name in `TALLCMS_MEDIA_DISK` must match a key in the `disks` array in `config/filesystems.php`. Check for typos and run `php artisan config:clear` after any config change.
 
 **"Can't delete image"**
 Images used in published content may be protected. Remove the image from content first.

--- a/packages/tallcms/cms/config/tallcms.php
+++ b/packages/tallcms/cms/config/tallcms.php
@@ -560,6 +560,11 @@ return [
     |
     */
     'media' => [
+        // Filesystem disk to use for media uploads.
+        // Set TALLCMS_MEDIA_DISK in your .env to any disk defined in config/filesystems.php.
+        // When null, TallCMS auto-detects: 's3' if S3 is configured, otherwise 'public'.
+        'disk' => env('TALLCMS_MEDIA_DISK'),
+
         'optimization' => [
             // Enable or disable automatic image optimization
             'enabled' => env('TALLCMS_MEDIA_OPTIMIZATION', true),

--- a/packages/tallcms/cms/src/Filament/Resources/TallcmsMedia/Pages/EditTallcmsMedia.php
+++ b/packages/tallcms/cms/src/Filament/Resources/TallcmsMedia/Pages/EditTallcmsMedia.php
@@ -7,6 +7,8 @@ use Filament\Resources\Pages\EditRecord;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
 use TallCms\Cms\Filament\Resources\TallcmsMedia\TallcmsMediaResource;
+use TallCms\Cms\Jobs\OptimizeMediaJob;
+use TallCms\Cms\Services\ImageOptimizer;
 
 class EditTallcmsMedia extends EditRecord
 {
@@ -24,6 +26,8 @@ class EditTallcmsMedia extends EditRecord
 
     protected function handleRecordUpdate(Model $record, array $data): Model
     {
+        $isImageReplacement = false;
+
         // Handle file replacement
         if (! empty($data['new_file'])) {
             $newFilePath = $data['new_file'];
@@ -43,6 +47,7 @@ class EditTallcmsMedia extends EditRecord
             // Get image dimensions if it's an image
             $meta = $record->meta ?? [];
             if (str_starts_with($mimeType, 'image/')) {
+                $isImageReplacement = true;
                 if ($disk === 'public') {
                     $fullPath = Storage::disk($disk)->path($newFilePath);
                     if (file_exists($fullPath)) {
@@ -65,6 +70,12 @@ class EditTallcmsMedia extends EditRecord
                 }
             }
 
+            // Variants belong to the old file; drop them so URLs don't point at the wrong image.
+            if ($record->has_variants) {
+                app(ImageOptimizer::class)->deleteVariants($record);
+            }
+            unset($meta['variants']);
+
             // Update file metadata
             $data = array_merge($data, [
                 'file_name' => $originalName,
@@ -73,6 +84,8 @@ class EditTallcmsMedia extends EditRecord
                 'disk' => $disk,
                 'size' => $size,
                 'meta' => $meta,
+                'has_variants' => false,
+                'optimized_at' => null,
             ]);
         }
 
@@ -80,6 +93,11 @@ class EditTallcmsMedia extends EditRecord
         unset($data['new_file']);
 
         $record->update($data);
+
+        if ($isImageReplacement && config('tallcms.media.optimization.enabled', true)) {
+            OptimizeMediaJob::dispatch($record)
+                ->onQueue(config('tallcms.media.optimization.queue', 'default'));
+        }
 
         return $record;
     }

--- a/packages/tallcms/cms/src/Filament/Resources/TallcmsMedia/Pages/EditTallcmsMedia.php
+++ b/packages/tallcms/cms/src/Filament/Resources/TallcmsMedia/Pages/EditTallcmsMedia.php
@@ -41,13 +41,27 @@ class EditTallcmsMedia extends EditRecord
             $size = Storage::disk($disk)->size($newFilePath);
 
             // Get image dimensions if it's an image
-            // Note: For S3, we can't use getimagesize directly, so we skip dimensions for remote storage
             $meta = $record->meta ?? [];
-            if (str_starts_with($mimeType, 'image/') && $disk === 'public') {
-                $fullPath = Storage::disk($disk)->path($newFilePath);
-                if (file_exists($fullPath)) {
-                    [$width, $height] = getimagesize($fullPath);
-                    $meta = array_merge($meta, ['width' => $width, 'height' => $height]);
+            if (str_starts_with($mimeType, 'image/')) {
+                if ($disk === 'public') {
+                    $fullPath = Storage::disk($disk)->path($newFilePath);
+                    if (file_exists($fullPath)) {
+                        [$width, $height] = @getimagesize($fullPath);
+                        if ($width && $height) {
+                            $meta = array_merge($meta, ['width' => $width, 'height' => $height]);
+                        }
+                    }
+                } else {
+                    $tempPath = sys_get_temp_dir().'/'.uniqid('media_dim_').'.'.pathinfo($newFilePath, PATHINFO_EXTENSION);
+                    try {
+                        file_put_contents($tempPath, Storage::disk($disk)->get($newFilePath));
+                        [$width, $height] = @getimagesize($tempPath);
+                        if ($width && $height) {
+                            $meta = array_merge($meta, ['width' => $width, 'height' => $height]);
+                        }
+                    } finally {
+                        @unlink($tempPath);
+                    }
                 }
             }
 

--- a/packages/tallcms/cms/src/Http/Controllers/Api/V1/MediaController.php
+++ b/packages/tallcms/cms/src/Http/Controllers/Api/V1/MediaController.php
@@ -6,7 +6,6 @@ namespace TallCms\Cms\Http\Controllers\Api\V1;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Storage;
 use TallCms\Cms\Http\Controllers\Api\V1\Concerns\HandlesFiltering;
 use TallCms\Cms\Http\Controllers\Api\V1\Concerns\HandlesIncludes;
 use TallCms\Cms\Http\Controllers\Api\V1\Concerns\HandlesPagination;
@@ -206,20 +205,19 @@ class MediaController extends Controller
         $this->authorize('create', TallcmsMedia::class);
 
         $file = $request->file('file');
-        $disk = $request->input('disk', 'public');
+        $disk = cms_media_disk();
 
         // Store the file
         $path = $file->store('media', $disk);
 
         // Get image dimensions if it's an image
-        $width = null;
-        $height = null;
+        $meta = [];
 
         if (str_starts_with($file->getMimeType(), 'image/')) {
-            $imageInfo = getimagesize($file->getPathname());
+            $imageInfo = @getimagesize($file->getPathname());
             if ($imageInfo) {
-                $width = $imageInfo[0];
-                $height = $imageInfo[1];
+                $meta['width'] = $imageInfo[0];
+                $meta['height'] = $imageInfo[1];
             }
         }
 
@@ -230,10 +228,9 @@ class MediaController extends Controller
             'disk' => $disk,
             'mime_type' => $file->getMimeType(),
             'size' => $file->getSize(),
+            'meta' => $meta,
             'alt_text' => $request->input('alt_text'),
             'caption' => $request->input('caption'),
-            'width' => $width,
-            'height' => $height,
         ]);
 
         // Sync collections if provided (validate ownership)
@@ -282,16 +279,7 @@ class MediaController extends Controller
 
         $this->authorize('delete', $mediaModel);
 
-        // Delete the file from storage
-        Storage::disk($mediaModel->disk)->delete($mediaModel->path);
-
-        // Delete variants if any
-        if ($mediaModel->variants) {
-            foreach ($mediaModel->variants as $variant => $variantPath) {
-                Storage::disk($mediaModel->disk)->delete($variantPath);
-            }
-        }
-
+        // File and variant deletion is handled by the model's deleting hook
         $mediaModel->delete();
 
         return $this->respondWithMessage('Media deleted successfully');

--- a/packages/tallcms/cms/src/Http/Controllers/Api/V1/MediaController.php
+++ b/packages/tallcms/cms/src/Http/Controllers/Api/V1/MediaController.php
@@ -82,11 +82,7 @@ class MediaController extends Controller
         if ($field === 'has_variants') {
             $hasVariants = filter_var($value, FILTER_VALIDATE_BOOLEAN);
 
-            return $hasVariants
-                ? $query->whereNotNull('variants')->where('variants', '!=', '[]')
-                : $query->where(function ($q) {
-                    $q->whereNull('variants')->orWhere('variants', '[]');
-                });
+            return $query->where('has_variants', $hasVariants);
         }
 
         // Handle mime_type filter with wildcard support (e.g., image/*)

--- a/packages/tallcms/cms/src/Http/Requests/Api/V1/StoreMediaRequest.php
+++ b/packages/tallcms/cms/src/Http/Requests/Api/V1/StoreMediaRequest.php
@@ -28,7 +28,6 @@ class StoreMediaRequest extends FormRequest
         return [
             'file' => ['required', 'file', 'max:102400'], // 100MB max
             'name' => ['sometimes', 'string', 'max:255'],
-            'disk' => ['sometimes', 'string', 'in:public,s3,local'],
             'alt_text' => ['sometimes', 'nullable', 'string', 'max:255'],
             'caption' => ['sometimes', 'nullable', 'string', 'max:1000'],
             'collection_ids' => ['sometimes', 'array'],

--- a/packages/tallcms/cms/src/Http/Resources/Api/V1/MediaResource.php
+++ b/packages/tallcms/cms/src/Http/Resources/Api/V1/MediaResource.php
@@ -33,7 +33,7 @@ class MediaResource extends JsonResource
             'height' => $this->height,
             'url' => $this->url,
             'is_image' => $this->isImage,
-            'variants' => $this->when($this->variants, $this->variants),
+            'variants' => $this->when(isset($this->meta['variants']), $this->meta['variants'] ?? null),
             'download_url' => $this->downloadUrl,
             'created_at' => $this->created_at?->toIso8601String(),
             'updated_at' => $this->updated_at?->toIso8601String(),

--- a/packages/tallcms/cms/src/helpers.php
+++ b/packages/tallcms/cms/src/helpers.php
@@ -310,7 +310,13 @@ if (! function_exists('cms_media_disk')) {
      */
     function cms_media_disk(): string
     {
-        // First, check if FILESYSTEM_DISK is explicitly set to s3
+        // Explicit package-level override takes highest priority
+        $configured = config('tallcms.media.disk');
+        if (! empty($configured)) {
+            return $configured;
+        }
+
+        // Auto-detect: check if FILESYSTEM_DISK is explicitly set to s3
         $defaultDisk = config('filesystems.default');
         if ($defaultDisk === 's3') {
             return 's3';
@@ -346,7 +352,10 @@ if (! function_exists('cms_uses_s3')) {
      */
     function cms_uses_s3(): bool
     {
-        return cms_media_disk() === 's3';
+        $disk = cms_media_disk();
+
+        return $disk === 's3'
+            || config("filesystems.disks.{$disk}.driver") === 's3';
     }
 }
 

--- a/packages/tallcms/cms/tests/Feature/Api/MediaControllerTest.php
+++ b/packages/tallcms/cms/tests/Feature/Api/MediaControllerTest.php
@@ -321,4 +321,127 @@ class MediaControllerTest extends TestCase
         $this->deleteJson('/api/v1/tallcms/media/99999')
             ->assertStatus(404);
     }
+
+    // -------------------------------------------------------------------------
+    // index — has_variants filter
+    // -------------------------------------------------------------------------
+
+    public function test_index_filter_has_variants_true_returns_only_optimized_items(): void
+    {
+        Storage::fake('public');
+        $this->actingAsMediaUser();
+
+        $withVariants = TallcmsMedia::create([
+            'name' => 'optimized',
+            'file_name' => 'photo.jpg',
+            'mime_type' => 'image/jpeg',
+            'path' => 'media/photo.jpg',
+            'disk' => 'public',
+            'size' => 1000,
+            'has_variants' => true,
+            'meta' => ['variants' => ['thumbnail' => 'media/photo-thumbnail.webp']],
+        ]);
+
+        TallcmsMedia::create([
+            'name' => 'raw',
+            'file_name' => 'raw.jpg',
+            'mime_type' => 'image/jpeg',
+            'path' => 'media/raw.jpg',
+            'disk' => 'public',
+            'size' => 1000,
+            'has_variants' => false,
+        ]);
+
+        $response = $this->getJson('/api/v1/tallcms/media?filter[has_variants]=true');
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data'))->pluck('id');
+        $this->assertTrue($ids->contains($withVariants->id));
+        $this->assertCount(1, $ids);
+    }
+
+    public function test_index_filter_has_variants_false_excludes_optimized_items(): void
+    {
+        Storage::fake('public');
+        $this->actingAsMediaUser();
+
+        TallcmsMedia::create([
+            'name' => 'optimized',
+            'file_name' => 'photo.jpg',
+            'mime_type' => 'image/jpeg',
+            'path' => 'media/photo.jpg',
+            'disk' => 'public',
+            'size' => 1000,
+            'has_variants' => true,
+            'meta' => ['variants' => ['thumbnail' => 'media/photo-thumbnail.webp']],
+        ]);
+
+        $raw = TallcmsMedia::create([
+            'name' => 'raw',
+            'file_name' => 'raw.jpg',
+            'mime_type' => 'image/jpeg',
+            'path' => 'media/raw.jpg',
+            'disk' => 'public',
+            'size' => 1000,
+            'has_variants' => false,
+        ]);
+
+        $response = $this->getJson('/api/v1/tallcms/media?filter[has_variants]=false');
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data'))->pluck('id');
+        $this->assertTrue($ids->contains($raw->id));
+        $this->assertCount(1, $ids);
+    }
+
+    // -------------------------------------------------------------------------
+    // show — resource includes variants from meta
+    // -------------------------------------------------------------------------
+
+    public function test_show_resource_includes_variants_when_meta_variants_populated(): void
+    {
+        Storage::fake('public');
+        $this->actingAsMediaUser();
+
+        $media = TallcmsMedia::create([
+            'name' => 'photo',
+            'file_name' => 'photo.jpg',
+            'mime_type' => 'image/jpeg',
+            'path' => 'media/photo.jpg',
+            'disk' => 'public',
+            'size' => 1000,
+            'has_variants' => true,
+            'meta' => [
+                'variants' => [
+                    'thumbnail' => 'media/photo-thumbnail.webp',
+                    'medium' => 'media/photo-medium.webp',
+                ],
+            ],
+        ]);
+
+        $this->getJson("/api/v1/tallcms/media/{$media->id}")
+            ->assertStatus(200)
+            ->assertJsonPath('data.variants.thumbnail', 'media/photo-thumbnail.webp')
+            ->assertJsonPath('data.variants.medium', 'media/photo-medium.webp');
+    }
+
+    public function test_show_resource_omits_variants_key_when_none_exist(): void
+    {
+        Storage::fake('public');
+        $this->actingAsMediaUser();
+
+        $media = TallcmsMedia::create([
+            'name' => 'raw',
+            'file_name' => 'raw.jpg',
+            'mime_type' => 'image/jpeg',
+            'path' => 'media/raw.jpg',
+            'disk' => 'public',
+            'size' => 1000,
+            'has_variants' => false,
+        ]);
+
+        $response = $this->getJson("/api/v1/tallcms/media/{$media->id}");
+        $response->assertStatus(200);
+        $this->assertArrayNotHasKey('variants', $response->json('data'));
+    }
 }

--- a/packages/tallcms/cms/tests/Feature/Api/MediaControllerTest.php
+++ b/packages/tallcms/cms/tests/Feature/Api/MediaControllerTest.php
@@ -1,0 +1,324 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TallCms\Cms\Tests\Feature\Api;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Sanctum\Sanctum;
+use TallCms\Cms\Models\TallcmsMedia;
+use TallCms\Cms\Policies\TallcmsMediaPolicy;
+use TallCms\Cms\Tests\TestCase;
+
+class MediaControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['tallcms.api.enabled' => true]);
+    }
+
+    protected function createUser(): object
+    {
+        $userModel = config('tallcms.plugin_mode.user_model', 'App\\Models\\User');
+
+        return $userModel::create([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => Hash::make('password'),
+        ]);
+    }
+
+    protected function actingAsMediaUser(): void
+    {
+        Sanctum::actingAs($this->createUser(), ['*']);
+
+        $this->mock(TallcmsMediaPolicy::class, function ($mock) {
+            $mock->shouldReceive('viewAny')->andReturn(true);
+            $mock->shouldReceive('view')->andReturn(true);
+            $mock->shouldReceive('create')->andReturn(true);
+            $mock->shouldReceive('update')->andReturn(true);
+            $mock->shouldReceive('delete')->andReturn(true);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // store
+    // -------------------------------------------------------------------------
+
+    public function test_store_uploads_file_to_configured_media_disk(): void
+    {
+        Storage::fake('custom-disk');
+        config(['tallcms.media.disk' => 'custom-disk']);
+        $this->actingAsMediaUser();
+
+        $response = $this->postJson('/api/v1/tallcms/media', [
+            'file' => UploadedFile::fake()->create('report.pdf', 100, 'application/pdf'),
+        ]);
+
+        $response->assertStatus(201);
+        $media = TallcmsMedia::findOrFail($response->json('data.id'));
+        $this->assertSame('custom-disk', $media->disk);
+        Storage::disk('custom-disk')->assertExists($media->path);
+    }
+
+    public function test_store_falls_back_to_auto_detected_disk_when_not_configured(): void
+    {
+        Storage::fake('public');
+        config(['tallcms.media.disk' => null, 'filesystems.default' => 'public']);
+        $this->actingAsMediaUser();
+
+        $response = $this->postJson('/api/v1/tallcms/media', [
+            'file' => UploadedFile::fake()->create('report.pdf', 100, 'application/pdf'),
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertSame('public', TallcmsMedia::findOrFail($response->json('data.id'))->disk);
+    }
+
+    public function test_store_ignores_disk_parameter_from_request(): void
+    {
+        Storage::fake('public');
+        config(['tallcms.media.disk' => null, 'filesystems.default' => 'public']);
+        $this->actingAsMediaUser();
+
+        $response = $this->postJson('/api/v1/tallcms/media', [
+            'file' => UploadedFile::fake()->create('report.pdf', 100, 'application/pdf'),
+            'disk' => 'local', // must be ignored
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertSame('public', TallcmsMedia::findOrFail($response->json('data.id'))->disk);
+    }
+
+    public function test_store_saves_image_dimensions_in_meta(): void
+    {
+        Storage::fake('public');
+        $this->actingAsMediaUser();
+
+        $response = $this->postJson('/api/v1/tallcms/media', [
+            'file' => UploadedFile::fake()->image('photo.jpg', 640, 480),
+        ]);
+
+        $response->assertStatus(201);
+        $media = TallcmsMedia::findOrFail($response->json('data.id'));
+        $this->assertSame(640, $media->meta['width']);
+        $this->assertSame(480, $media->meta['height']);
+    }
+
+    public function test_store_dimensions_are_accessible_via_accessors(): void
+    {
+        Storage::fake('public');
+        $this->actingAsMediaUser();
+
+        $response = $this->postJson('/api/v1/tallcms/media', [
+            'file' => UploadedFile::fake()->image('photo.jpg', 800, 600),
+        ]);
+
+        $response->assertStatus(201);
+        $media = TallcmsMedia::findOrFail($response->json('data.id'));
+        $this->assertSame(800, $media->width);
+        $this->assertSame(600, $media->height);
+    }
+
+    public function test_store_does_not_set_dimensions_for_non_image(): void
+    {
+        Storage::fake('public');
+        $this->actingAsMediaUser();
+
+        $response = $this->postJson('/api/v1/tallcms/media', [
+            'file' => UploadedFile::fake()->create('document.pdf', 200, 'application/pdf'),
+        ]);
+
+        $response->assertStatus(201);
+        $media = TallcmsMedia::findOrFail($response->json('data.id'));
+        $this->assertEmpty($media->meta);
+        $this->assertNull($media->width);
+        $this->assertNull($media->height);
+    }
+
+    public function test_store_creates_record_with_correct_metadata(): void
+    {
+        Storage::fake('public');
+        $this->actingAsMediaUser();
+
+        $response = $this->postJson('/api/v1/tallcms/media', [
+            'file' => UploadedFile::fake()->create('brochure.pdf', 512, 'application/pdf'),
+            'name' => 'Company Brochure',
+            'alt_text' => 'Our company overview',
+            'caption' => 'Version 2024',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.name', 'Company Brochure')
+            ->assertJsonPath('data.mime_type', 'application/pdf')
+            ->assertJsonPath('data.alt_text', 'Our company overview')
+            ->assertJsonPath('data.caption', 'Version 2024');
+
+        $this->assertDatabaseHas('tallcms_media', [
+            'name' => 'Company Brochure',
+            'alt_text' => 'Our company overview',
+            'caption' => 'Version 2024',
+        ]);
+    }
+
+    public function test_store_uses_original_filename_as_name_when_not_provided(): void
+    {
+        Storage::fake('public');
+        $this->actingAsMediaUser();
+
+        $response = $this->postJson('/api/v1/tallcms/media', [
+            'file' => UploadedFile::fake()->create('my-report.pdf', 100, 'application/pdf'),
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.name', 'my-report.pdf');
+    }
+
+    public function test_store_handles_unreadable_image_gracefully(): void
+    {
+        Storage::fake('public');
+        $this->actingAsMediaUser();
+
+        // A file claiming to be JPEG but with invalid image content
+        $response = $this->postJson('/api/v1/tallcms/media', [
+            'file' => UploadedFile::fake()->create('corrupt.jpg', 10, 'image/jpeg'),
+        ]);
+
+        $response->assertStatus(201);
+        $media = TallcmsMedia::findOrFail($response->json('data.id'));
+        $this->assertEmpty($media->meta); // dimensions skipped gracefully, no 500
+    }
+
+    public function test_store_requires_authentication(): void
+    {
+        Storage::fake('public');
+
+        $response = $this->postJson('/api/v1/tallcms/media', [
+            'file' => UploadedFile::fake()->create('doc.pdf', 50, 'application/pdf'),
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_store_validates_file_is_required(): void
+    {
+        Storage::fake('public');
+        $this->actingAsMediaUser();
+
+        $response = $this->postJson('/api/v1/tallcms/media', []);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['file']);
+    }
+
+    // -------------------------------------------------------------------------
+    // destroy
+    // -------------------------------------------------------------------------
+
+    public function test_destroy_deletes_file_from_model_disk(): void
+    {
+        Storage::fake('public');
+        Storage::disk('public')->put('media/test.pdf', 'content');
+        $this->actingAsMediaUser();
+
+        $media = TallcmsMedia::create([
+            'name' => 'test',
+            'file_name' => 'test.pdf',
+            'mime_type' => 'application/pdf',
+            'path' => 'media/test.pdf',
+            'disk' => 'public',
+            'size' => 7,
+        ]);
+
+        $this->deleteJson("/api/v1/tallcms/media/{$media->id}")
+            ->assertStatus(200);
+
+        Storage::disk('public')->assertMissing('media/test.pdf');
+        $this->assertDatabaseMissing('tallcms_media', ['id' => $media->id]);
+    }
+
+    public function test_destroy_deletes_file_from_custom_disk(): void
+    {
+        Storage::fake('cms-media');
+        Storage::disk('cms-media')->put('media/file.pdf', 'content');
+        $this->actingAsMediaUser();
+
+        $media = TallcmsMedia::create([
+            'name' => 'file',
+            'file_name' => 'file.pdf',
+            'mime_type' => 'application/pdf',
+            'path' => 'media/file.pdf',
+            'disk' => 'cms-media',
+            'size' => 7,
+        ]);
+
+        $this->deleteJson("/api/v1/tallcms/media/{$media->id}")
+            ->assertStatus(200);
+
+        Storage::disk('cms-media')->assertMissing('media/file.pdf');
+    }
+
+    public function test_destroy_deletes_variants_via_model_hook(): void
+    {
+        Storage::fake('public');
+        Storage::disk('public')->put('media/photo.jpg', 'original');
+        Storage::disk('public')->put('media/photo-thumbnail.webp', 'thumb');
+        Storage::disk('public')->put('media/photo-medium.webp', 'medium');
+        $this->actingAsMediaUser();
+
+        $media = TallcmsMedia::create([
+            'name' => 'photo',
+            'file_name' => 'photo.jpg',
+            'mime_type' => 'image/jpeg',
+            'path' => 'media/photo.jpg',
+            'disk' => 'public',
+            'size' => 1000,
+            'has_variants' => true,
+            'meta' => [
+                'variants' => [
+                    'thumbnail' => 'media/photo-thumbnail.webp',
+                    'medium' => 'media/photo-medium.webp',
+                ],
+            ],
+        ]);
+
+        $this->deleteJson("/api/v1/tallcms/media/{$media->id}")
+            ->assertStatus(200);
+
+        Storage::disk('public')->assertMissing('media/photo.jpg');
+        Storage::disk('public')->assertMissing('media/photo-thumbnail.webp');
+        Storage::disk('public')->assertMissing('media/photo-medium.webp');
+    }
+
+    public function test_destroy_requires_authentication(): void
+    {
+        Storage::fake('public');
+        Storage::disk('public')->put('media/file.pdf', 'content');
+
+        $media = TallcmsMedia::create([
+            'name' => 'file',
+            'file_name' => 'file.pdf',
+            'mime_type' => 'application/pdf',
+            'path' => 'media/file.pdf',
+            'disk' => 'public',
+            'size' => 7,
+        ]);
+
+        $this->deleteJson("/api/v1/tallcms/media/{$media->id}")
+            ->assertStatus(401);
+    }
+
+    public function test_destroy_returns_404_for_missing_media(): void
+    {
+        $this->actingAsMediaUser();
+
+        $this->deleteJson('/api/v1/tallcms/media/99999')
+            ->assertStatus(404);
+    }
+}

--- a/packages/tallcms/cms/tests/Unit/MediaDiskHelperTest.php
+++ b/packages/tallcms/cms/tests/Unit/MediaDiskHelperTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace TallCms\Cms\Tests\Unit;
+
+use TallCms\Cms\Tests\TestCase;
+
+class MediaDiskHelperTest extends TestCase
+{
+    public function test_media_disk_uses_explicit_package_config(): void
+    {
+        config(['tallcms.media.disk' => 'cms-media']);
+
+        $this->assertSame('cms-media', cms_media_disk());
+    }
+
+    public function test_media_disk_falls_back_to_s3_detection_when_not_configured(): void
+    {
+        config([
+            'tallcms.media.disk' => null,
+            'filesystems.default' => 's3',
+        ]);
+
+        $this->assertSame('s3', cms_media_disk());
+    }
+
+    public function test_media_uses_s3_detects_custom_s3_driver(): void
+    {
+        config([
+            'tallcms.media.disk' => 'cms-media',
+            'filesystems.disks.cms-media' => [
+                'driver' => 's3',
+                'bucket' => 'cms-bucket',
+            ],
+        ]);
+
+        $this->assertTrue(cms_uses_s3());
+    }
+}

--- a/packages/tallcms/cms/tests/Unit/TallcmsMediaModelTest.php
+++ b/packages/tallcms/cms/tests/Unit/TallcmsMediaModelTest.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TallCms\Cms\Tests\Unit;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use TallCms\Cms\Models\TallcmsMedia;
+use TallCms\Cms\Tests\TestCase;
+
+class TallcmsMediaModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    protected function makeMedia(array $overrides = []): TallcmsMedia
+    {
+        return TallcmsMedia::create(array_merge([
+            'name' => 'test-file',
+            'file_name' => 'test-file.jpg',
+            'mime_type' => 'image/jpeg',
+            'path' => 'media/test-file.jpg',
+            'disk' => 'public',
+            'size' => 1024,
+        ], $overrides));
+    }
+
+    // -------------------------------------------------------------------------
+    // Deletion — original file
+    // -------------------------------------------------------------------------
+
+    public function test_delete_removes_file_from_disk(): void
+    {
+        Storage::fake('public');
+        Storage::disk('public')->put('media/test-file.jpg', 'content');
+
+        $media = $this->makeMedia();
+
+        $media->delete();
+
+        Storage::disk('public')->assertMissing('media/test-file.jpg');
+    }
+
+    public function test_delete_removes_file_from_custom_disk(): void
+    {
+        Storage::fake('cms-media');
+        Storage::disk('cms-media')->put('media/test-file.jpg', 'content');
+
+        $media = $this->makeMedia(['disk' => 'cms-media']);
+
+        $media->delete();
+
+        Storage::disk('cms-media')->assertMissing('media/test-file.jpg');
+    }
+
+    public function test_delete_does_not_error_when_file_already_missing(): void
+    {
+        Storage::fake('public');
+        // Intentionally not putting the file on disk
+
+        $media = $this->makeMedia();
+
+        // Should not throw
+        $media->delete();
+
+        $this->assertDatabaseMissing('tallcms_media', ['id' => $media->id]);
+    }
+
+    public function test_delete_removes_record_from_database(): void
+    {
+        Storage::fake('public');
+        Storage::disk('public')->put('media/test-file.jpg', 'content');
+
+        $media = $this->makeMedia();
+        $id = $media->id;
+
+        $media->delete();
+
+        $this->assertNull(TallcmsMedia::find($id));
+    }
+
+    // -------------------------------------------------------------------------
+    // Deletion — variants
+    // -------------------------------------------------------------------------
+
+    public function test_delete_removes_variant_files_from_disk(): void
+    {
+        Storage::fake('public');
+        Storage::disk('public')->put('media/photo.jpg', 'original');
+        Storage::disk('public')->put('media/photo-thumbnail.webp', 'thumb');
+        Storage::disk('public')->put('media/photo-medium.webp', 'medium');
+        Storage::disk('public')->put('media/photo-large.webp', 'large');
+
+        $media = $this->makeMedia([
+            'path' => 'media/photo.jpg',
+            'has_variants' => true,
+            'meta' => [
+                'variants' => [
+                    'thumbnail' => 'media/photo-thumbnail.webp',
+                    'medium' => 'media/photo-medium.webp',
+                    'large' => 'media/photo-large.webp',
+                ],
+            ],
+        ]);
+
+        $media->delete();
+
+        Storage::disk('public')->assertMissing('media/photo.jpg');
+        Storage::disk('public')->assertMissing('media/photo-thumbnail.webp');
+        Storage::disk('public')->assertMissing('media/photo-medium.webp');
+        Storage::disk('public')->assertMissing('media/photo-large.webp');
+    }
+
+    public function test_delete_removes_variants_from_custom_disk(): void
+    {
+        Storage::fake('cms-media');
+        Storage::disk('cms-media')->put('media/photo.jpg', 'original');
+        Storage::disk('cms-media')->put('media/photo-thumbnail.webp', 'thumb');
+
+        $media = $this->makeMedia([
+            'disk' => 'cms-media',
+            'path' => 'media/photo.jpg',
+            'has_variants' => true,
+            'meta' => [
+                'variants' => [
+                    'thumbnail' => 'media/photo-thumbnail.webp',
+                ],
+            ],
+        ]);
+
+        $media->delete();
+
+        Storage::disk('cms-media')->assertMissing('media/photo.jpg');
+        Storage::disk('cms-media')->assertMissing('media/photo-thumbnail.webp');
+    }
+
+    public function test_delete_skips_variant_cleanup_when_has_variants_is_false(): void
+    {
+        Storage::fake('public');
+        Storage::disk('public')->put('media/photo.jpg', 'content');
+
+        $media = $this->makeMedia([
+            'path' => 'media/photo.jpg',
+            'has_variants' => false,
+            'meta' => [],
+        ]);
+
+        // Should not throw even though there are no variants to clean up
+        $media->delete();
+
+        Storage::disk('public')->assertMissing('media/photo.jpg');
+    }
+
+    // -------------------------------------------------------------------------
+    // URL generation
+    // -------------------------------------------------------------------------
+
+    public function test_url_attribute_uses_model_disk(): void
+    {
+        Storage::fake('public');
+        Storage::disk('public')->put('media/photo.jpg', 'content');
+
+        $media = $this->makeMedia(['path' => 'media/photo.jpg', 'disk' => 'public']);
+
+        $this->assertStringContainsString('media/photo.jpg', $media->url);
+    }
+
+    public function test_url_attribute_uses_custom_disk(): void
+    {
+        Storage::fake('cms-media');
+        Storage::disk('cms-media')->put('media/photo.jpg', 'content');
+
+        $media = $this->makeMedia(['path' => 'media/photo.jpg', 'disk' => 'cms-media']);
+
+        $this->assertStringContainsString('media/photo.jpg', $media->url);
+    }
+
+    public function test_get_variant_url_returns_variant_path_from_model_disk(): void
+    {
+        Storage::fake('public');
+        Storage::disk('public')->put('media/photo.jpg', 'original');
+        Storage::disk('public')->put('media/photo-medium.webp', 'medium');
+
+        $media = $this->makeMedia([
+            'path' => 'media/photo.jpg',
+            'disk' => 'public',
+            'has_variants' => true,
+            'meta' => [
+                'variants' => ['medium' => 'media/photo-medium.webp'],
+            ],
+        ]);
+
+        $url = $media->getVariantUrl('medium');
+
+        $this->assertStringContainsString('media/photo-medium.webp', $url);
+    }
+
+    public function test_get_variant_url_falls_back_to_original_when_variant_absent(): void
+    {
+        Storage::fake('public');
+        Storage::disk('public')->put('media/photo.jpg', 'original');
+
+        $media = $this->makeMedia(['path' => 'media/photo.jpg', 'meta' => []]);
+
+        $url = $media->getVariantUrl('thumbnail');
+
+        $this->assertStringContainsString('media/photo.jpg', $url);
+    }
+
+    public function test_get_variant_url_uses_custom_disk_for_variants(): void
+    {
+        Storage::fake('cms-media');
+        Storage::disk('cms-media')->put('media/photo.jpg', 'original');
+        Storage::disk('cms-media')->put('media/photo-thumbnail.webp', 'thumb');
+
+        $media = $this->makeMedia([
+            'disk' => 'cms-media',
+            'path' => 'media/photo.jpg',
+            'has_variants' => true,
+            'meta' => [
+                'variants' => ['thumbnail' => 'media/photo-thumbnail.webp'],
+            ],
+        ]);
+
+        $url = $media->getVariantUrl('thumbnail');
+
+        $this->assertStringContainsString('media/photo-thumbnail.webp', $url);
+    }
+
+    // -------------------------------------------------------------------------
+    // Accessors — width / height from meta
+    // -------------------------------------------------------------------------
+
+    public function test_width_and_height_accessors_read_from_meta(): void
+    {
+        Storage::fake('public');
+
+        $media = $this->makeMedia([
+            'meta' => ['width' => 1920, 'height' => 1080],
+        ]);
+
+        $this->assertSame(1920, $media->width);
+        $this->assertSame(1080, $media->height);
+    }
+
+    public function test_width_and_height_accessors_return_null_when_meta_absent(): void
+    {
+        Storage::fake('public');
+
+        $media = $this->makeMedia(['meta' => []]);
+
+        $this->assertNull($media->width);
+        $this->assertNull($media->height);
+    }
+
+    public function test_dimensions_attribute_formats_width_by_height(): void
+    {
+        Storage::fake('public');
+
+        $media = $this->makeMedia([
+            'meta' => ['width' => 800, 'height' => 600],
+        ]);
+
+        $this->assertSame('800 × 600', $media->dimensions);
+    }
+
+    public function test_dimensions_attribute_returns_null_when_meta_absent(): void
+    {
+        Storage::fake('public');
+
+        $media = $this->makeMedia(['meta' => []]);
+
+        $this->assertNull($media->dimensions);
+    }
+}


### PR DESCRIPTION
Introduces explicit media disk configuration so CMS media uploads can target any filesystem disk independently of the app's default.

Config & helpers
- Add `tallcms.media.disk` key (env: TALLCMS_MEDIA_DISK) to both the package and skeleton configs
- `cms_media_disk()` now checks `tallcms.media.disk` first, then falls back to existing S3 auto-detection
- `cms_uses_s3()` now also returns true when the configured disk's driver is 's3', so custom-named S3 disks are detected correctly

Bug fixes found during review
- EditTallcmsMedia: file replacement on any non-public disk silently skipped dimension extraction; add the same temp-file path already used in CreateTallcmsMedia
- MediaController: defaulted to 'public' disk instead of cms_media_disk(); accepted and validated a caller-supplied 'disk' field from the request body
- MediaController destroy(): manual Storage deletions before model->delete() were redundant (model hook handles it) and the variant loop accessed a non-existent attribute, silently doing nothing; remove the block entirely
- MediaController store(): width/height passed as top-level attributes not in $fillable; store in meta[] instead so accessors work correctly
- MediaController store(): getimagesize() was unchecked, causing 500 on files with image/* MIME type but invalid content; add @

@tallcms In case of any edits/updates/changes needed please let me know