### PR TITLE
Sweep AccentColor across 5 remaining hotspot blocks (PR 2 of 2)

### DIFF
--- a/packages/tallcms/cms/resources/themes/elevate/resources/views/cms/blocks/pricing.blade.php
+++ b/packages/tallcms/cms/resources/themes/elevate/resources/views/cms/blocks/pricing.blade.php
@@ -29,6 +29,11 @@
     $animationDuration = $animation_duration ?? 'anim-duration-500';
     $animationStagger = $animation_stagger ?? false;
     $staggerDelay = (int) ($animation_stagger_delay ?? 100);
+
+    $accent = $accent_color ?? 'primary';
+    $accentTint5 = \TallCms\Cms\Filament\Blocks\Support\AccentColor::tint5($accent);
+    $accentBorder = \TallCms\Cms\Filament\Blocks\Support\AccentColor::border($accent);
+    $accentShadow10 = \TallCms\Cms\Filament\Blocks\Support\AccentColor::shadow10($accent);
 @endphp
 
 <x-tallcms::animation-wrapper
@@ -85,13 +90,13 @@
                             // Card classes using daisyUI
                             $cardClasses = match($card_style) {
                                 'bordered' => $isPopular
-                                    ? 'card rounded-2xl bg-primary/5 scale-105 transform -translate-y-3 relative z-10 border-t-4 border-primary shadow-2xl shadow-primary/10'
+                                    ? "card rounded-2xl $accentTint5 scale-105 transform -translate-y-3 relative z-10 border-t-4 $accentBorder shadow-2xl $accentShadow10"
                                     : 'card rounded-2xl bg-base-100 border-2 border-base-300',
                                 'elevated' => $isPopular
-                                    ? 'card rounded-2xl bg-primary/5 scale-105 transform -translate-y-3 relative z-10 border-t-4 border-primary shadow-2xl shadow-primary/10'
+                                    ? "card rounded-2xl $accentTint5 scale-105 transform -translate-y-3 relative z-10 border-t-4 $accentBorder shadow-2xl $accentShadow10"
                                     : 'card rounded-2xl bg-base-200 shadow-lg',
                                 default => $isPopular
-                                    ? 'card rounded-2xl bg-primary/5 scale-105 transform -translate-y-3 relative z-10 border-t-4 border-primary shadow-2xl shadow-primary/10'
+                                    ? "card rounded-2xl $accentTint5 scale-105 transform -translate-y-3 relative z-10 border-t-4 $accentBorder shadow-2xl $accentShadow10"
                                     : 'card rounded-2xl bg-base-200 shadow-lg',
                             };
 
@@ -161,7 +166,7 @@
                                             @if($featureText)
                                                 <li class="flex items-start gap-3">
                                                     @if($isIncluded)
-                                                        <x-heroicon-s-check class="w-5 h-5 text-primary flex-shrink-0 mt-0.5" />
+                                                        <x-heroicon-s-check class="w-5 h-5 {{ \TallCms\Cms\Filament\Blocks\Support\AccentColor::text($accent) }} flex-shrink-0 mt-0.5" />
                                                     @else
                                                         <x-heroicon-s-x-mark class="w-5 h-5 text-base-content/40 flex-shrink-0 mt-0.5" />
                                                     @endif

--- a/packages/tallcms/cms/resources/themes/elevate/resources/views/cms/blocks/testimonials.blade.php
+++ b/packages/tallcms/cms/resources/themes/elevate/resources/views/cms/blocks/testimonials.blade.php
@@ -116,7 +116,7 @@
                                     </div>
                                 @else
                                     <div class="avatar placeholder">
-                                        <div class="w-14 rounded-full bg-primary/10 text-primary">
+                                        <div class="w-14 rounded-full @accent('tint10', $accent_color ?? 'primary') @accent('text', $accent_color ?? 'primary')">
                                             <span class="text-xl font-semibold">
                                                 {{ substr($testimonial['author_name'] ?? 'A', 0, 1) }}
                                             </span>
@@ -201,7 +201,7 @@
                                     </div>
                                 @else
                                     <div class="avatar placeholder">
-                                        <div class="w-12 h-12 rounded-full bg-primary/10 text-primary">
+                                        <div class="w-12 h-12 rounded-full @accent('tint10', $accent_color ?? 'primary') @accent('text', $accent_color ?? 'primary')">
                                             <span class="text-sm font-semibold">
                                                 {{ substr($testimonial['author_name'] ?? 'A', 0, 1) }}
                                             </span>

--- a/packages/tallcms/cms/resources/views/cms/blocks/how-to.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/how-to.blade.php
@@ -60,7 +60,7 @@
                     >
                         <div class="card-body">
                             <div class="flex items-start gap-4">
-                                <div class="flex-shrink-0 w-10 h-10 rounded-full bg-primary text-primary-content flex items-center justify-center font-bold text-lg">
+                                <div class="flex-shrink-0 w-10 h-10 rounded-full @accent('fill', $accent_color ?? 'primary') flex items-center justify-center font-bold text-lg">
                                     {{ $stepNumber }}
                                 </div>
                                 <div class="flex-1 min-w-0">

--- a/packages/tallcms/cms/resources/views/cms/blocks/partials/timeline-content.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/partials/timeline-content.blade.php
@@ -6,7 +6,7 @@
     <div class="card-body p-5 sm:p-6">
         {{-- Date shown in content regardless of numbered mode (number only affects node display) --}}
         @if(!empty($item['date']))
-            <span class="inline-block text-xs font-semibold text-primary mb-2">
+            <span class="inline-block text-xs font-semibold @accent('text', $accent_color ?? 'primary') mb-2">
                 {{ $item['date'] }}
             </span>
         @endif

--- a/packages/tallcms/cms/resources/views/cms/blocks/partials/timeline-node.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/partials/timeline-node.blade.php
@@ -1,19 +1,19 @@
 {{-- Timeline Node (circle with number, icon, or date) --}}
-<div class="w-12 h-12 sm:w-14 sm:h-14 rounded-full bg-primary/10 flex items-center justify-center ring-4 ring-base-100">
+<div class="w-12 h-12 sm:w-14 sm:h-14 rounded-full @accent('tint10', $accent_color ?? 'primary') flex items-center justify-center ring-4 ring-base-100">
     @if($isNumbered)
-        <span class="text-lg sm:text-xl font-bold text-primary">
+        <span class="text-lg sm:text-xl font-bold @accent('text', $accent_color ?? 'primary')">
             {{ $index + 1 }}
         </span>
     @elseif($isValidIcon)
         <x-dynamic-component
             :component="$iconName"
-            class="w-6 h-6 text-primary"
+            class="w-6 h-6 {{ \TallCms\Cms\Filament\Blocks\Support\AccentColor::text($accent_color ?? 'primary') }}"
         />
     @elseif(!empty($date))
-        <span class="text-xs font-semibold text-primary text-center leading-tight px-1 truncate w-full">
+        <span class="text-xs font-semibold @accent('text', $accent_color ?? 'primary') text-center leading-tight px-1 truncate w-full">
             {{ $date }}
         </span>
     @else
-        <div class="w-3 h-3 rounded-full bg-primary"></div>
+        <div class="w-3 h-3 rounded-full @accent('bg', $accent_color ?? 'primary')"></div>
     @endif
 </div>

--- a/packages/tallcms/cms/resources/views/cms/blocks/pricing.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/pricing.blade.php
@@ -29,6 +29,10 @@
     $animationDuration = $animation_duration ?? 'anim-duration-500';
     $animationStagger = $animation_stagger ?? false;
     $staggerDelay = (int) ($animation_stagger_delay ?? 100);
+
+    $accent = $accent_color ?? 'primary';
+    $accentTint5 = \TallCms\Cms\Filament\Blocks\Support\AccentColor::tint5($accent);
+    $accentBorder = \TallCms\Cms\Filament\Blocks\Support\AccentColor::border($accent);
 @endphp
 
 <x-tallcms::animation-wrapper
@@ -84,13 +88,13 @@
                         // Card classes using daisyUI
                         $cardClasses = match($card_style) {
                             'bordered' => $isPopular
-                                ? 'card bg-primary/5 border-2 border-primary'
+                                ? "card $accentTint5 border-2 $accentBorder"
                                 : 'card bg-base-100 border-2 border-base-300',
                             'elevated' => $isPopular
-                                ? 'card bg-primary/5 shadow-2xl scale-105 border-2 border-primary'
+                                ? "card $accentTint5 shadow-2xl scale-105 border-2 $accentBorder"
                                 : 'card bg-base-200 shadow-lg',
                             default => $isPopular
-                                ? 'card bg-primary/5 shadow-xl border-2 border-primary'
+                                ? "card $accentTint5 shadow-xl border-2 $accentBorder"
                                 : 'card bg-base-200 shadow-lg',
                         };
 

--- a/packages/tallcms/cms/resources/views/cms/blocks/stats.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/stats.blade.php
@@ -93,7 +93,7 @@
                     >
                         {{-- Icon --}}
                         @if(!empty($stat['icon']))
-                            <div class="stat-figure text-primary">
+                            <div class="stat-figure @accent('text', $accent_color ?? 'primary')">
                                 @php
                                     $iconName = str_replace(['heroicon-o-', 'heroicon-s-', 'heroicon-m-'], '', $stat['icon']);
                                     $iconStyle = str_starts_with($stat['icon'], 'heroicon-s-') ? 's' : 'o';
@@ -106,7 +106,7 @@
                         @endif
 
                         {{-- Value --}}
-                        <div class="stat-value text-primary">
+                        <div class="stat-value @accent('text', $accent_color ?? 'primary')">
                             @if(!empty($stat['prefix']))
                                 <span>{{ $stat['prefix'] }}</span>
                             @endif

--- a/packages/tallcms/cms/resources/views/cms/blocks/testimonials.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/testimonials.blade.php
@@ -65,7 +65,7 @@
                         >
                             <div class="card-body">
                                 @if($isQuoteMarks)
-                                    <div class="absolute top-4 left-6 text-6xl text-primary/20 font-serif leading-none">"</div>
+                                    <div class="absolute top-4 left-6 text-6xl @accent('text20', $accent_color ?? 'primary') font-serif leading-none">"</div>
                                 @endif
 
                                 {{-- Rating --}}
@@ -101,7 +101,7 @@
                                         </div>
                                     @else
                                         <div class="avatar placeholder">
-                                            <div class="w-14 rounded-full bg-primary/10 text-primary">
+                                            <div class="w-14 rounded-full @accent('tint10', $accent_color ?? 'primary') @accent('text', $accent_color ?? 'primary')">
                                                 <span class="text-xl font-semibold">
                                                     {{ substr($testimonial['author_name'] ?? 'A', 0, 1) }}
                                                 </span>
@@ -147,7 +147,7 @@
                         >
                             <div class="card-body">
                                 @if($isQuoteMarks)
-                                    <div class="absolute top-4 left-6 text-5xl text-primary/20 font-serif leading-none">"</div>
+                                    <div class="absolute top-4 left-6 text-5xl @accent('text20', $accent_color ?? 'primary') font-serif leading-none">"</div>
                                 @endif
 
                                 {{-- Rating --}}
@@ -183,7 +183,7 @@
                                         </div>
                                     @else
                                         <div class="avatar placeholder">
-                                            <div class="w-10 rounded-full bg-primary/10 text-primary">
+                                            <div class="w-10 rounded-full @accent('tint10', $accent_color ?? 'primary') @accent('text', $accent_color ?? 'primary')">
                                                 <span class="text-sm font-semibold">
                                                     {{ substr($testimonial['author_name'] ?? 'A', 0, 1) }}
                                                 </span>

--- a/packages/tallcms/cms/src/Filament/Blocks/HowToBlock.php
+++ b/packages/tallcms/cms/src/Filament/Blocks/HowToBlock.php
@@ -159,6 +159,12 @@ class HowToBlock extends RichContentCustomBlock
                                             ->options(static::getBackgroundOptions())
                                             ->default('bg-base-100'),
 
+                                        Select::make('accent_color')
+                                            ->label('Accent Color')
+                                            ->options(static::getAccentColorOptions())
+                                            ->default('primary')
+                                            ->helperText('Color used for step number circles'),
+
                                         Select::make('padding')
                                             ->label('Section Padding')
                                             ->options(static::getPaddingOptions())
@@ -223,6 +229,7 @@ class HowToBlock extends RichContentCustomBlock
             'contentWidthClass' => $widthConfig['class'],
             'contentPadding' => $widthConfig['padding'],
             'background' => $config['background'] ?? 'bg-base-100',
+            'accent_color' => $config['accent_color'] ?? 'primary',
             'padding' => $config['padding'] ?? 'py-16',
             'show_schema' => $config['show_schema'] ?? true,
             'first_section' => $config['first_section'] ?? false,

--- a/packages/tallcms/cms/src/Filament/Blocks/PricingBlock.php
+++ b/packages/tallcms/cms/src/Filament/Blocks/PricingBlock.php
@@ -275,6 +275,12 @@ class PricingBlock extends RichContentCustomBlock
                                             ->options(static::getBackgroundOptions())
                                             ->default('bg-base-100'),
 
+                                        Select::make('accent_color')
+                                            ->label('Accent Color')
+                                            ->options(static::getAccentColorOptions())
+                                            ->default('primary')
+                                            ->helperText('Color used for popular plan highlight'),
+
                                         Select::make('padding')
                                             ->label('Section Padding')
                                             ->options(static::getPaddingOptions())
@@ -329,6 +335,7 @@ class PricingBlock extends RichContentCustomBlock
             'contentWidthClass' => $widthConfig['class'],
             'contentPadding' => $widthConfig['padding'],
             'background' => $config['background'] ?? 'bg-base-100',
+            'accent_color' => $config['accent_color'] ?? 'primary',
             'padding' => $config['padding'] ?? 'py-16',
             'first_section' => $config['first_section'] ?? false,
             'anchor_id' => static::getAnchorId($config, $config['section_title'] ?? null),

--- a/packages/tallcms/cms/src/Filament/Blocks/StatsBlock.php
+++ b/packages/tallcms/cms/src/Filament/Blocks/StatsBlock.php
@@ -183,6 +183,12 @@ class StatsBlock extends RichContentCustomBlock
                                             ->options(static::getBackgroundOptions())
                                             ->default('bg-base-100'),
 
+                                        Select::make('accent_color')
+                                            ->label('Accent Color')
+                                            ->options(static::getAccentColorOptions())
+                                            ->default('primary')
+                                            ->helperText('Color used for stat icons and values'),
+
                                         Select::make('padding')
                                             ->label('Section Padding')
                                             ->options(static::getPaddingOptions())
@@ -239,6 +245,7 @@ class StatsBlock extends RichContentCustomBlock
             'contentWidthClass' => $widthConfig['class'],
             'contentPadding' => $widthConfig['padding'],
             'background' => $config['background'] ?? 'bg-base-100',
+            'accent_color' => $config['accent_color'] ?? 'primary',
             'padding' => $config['padding'] ?? 'py-16',
             'animate' => $config['animate'] ?? false,
             'first_section' => $config['first_section'] ?? false,

--- a/packages/tallcms/cms/src/Filament/Blocks/TestimonialsBlock.php
+++ b/packages/tallcms/cms/src/Filament/Blocks/TestimonialsBlock.php
@@ -199,6 +199,12 @@ class TestimonialsBlock extends RichContentCustomBlock
                                             ->options(static::getBackgroundOptions())
                                             ->default('bg-base-100'),
 
+                                        Select::make('accent_color')
+                                            ->label('Accent Color')
+                                            ->options(static::getAccentColorOptions())
+                                            ->default('primary')
+                                            ->helperText('Color used for quote marks and avatar accents'),
+
                                         Select::make('padding')
                                             ->label('Section Padding')
                                             ->options(static::getPaddingOptions())
@@ -264,6 +270,7 @@ class TestimonialsBlock extends RichContentCustomBlock
             'contentWidthClass' => $widthConfig['class'],
             'contentPadding' => $widthConfig['padding'],
             'background' => $config['background'] ?? 'bg-base-100',
+            'accent_color' => $config['accent_color'] ?? 'primary',
             'padding' => $config['padding'] ?? 'py-16',
             'show_rating' => $config['show_rating'] ?? true,
             'show_company_logo' => $config['show_company_logo'] ?? false,

--- a/packages/tallcms/cms/src/Filament/Blocks/TimelineBlock.php
+++ b/packages/tallcms/cms/src/Filament/Blocks/TimelineBlock.php
@@ -196,6 +196,12 @@ class TimelineBlock extends RichContentCustomBlock
                                             ->options(static::getBackgroundOptions())
                                             ->default('bg-base-100'),
 
+                                        Select::make('accent_color')
+                                            ->label('Accent Color')
+                                            ->options(static::getAccentColorOptions())
+                                            ->default('primary')
+                                            ->helperText('Color used for timeline node markers and date labels'),
+
                                         Select::make('padding')
                                             ->label('Section Padding')
                                             ->options(static::getPaddingOptions())
@@ -277,6 +283,7 @@ class TimelineBlock extends RichContentCustomBlock
             'contentWidthClass' => $widthConfig['class'],
             'contentPadding' => $widthConfig['padding'],
             'background' => $config['background'] ?? 'bg-base-100',
+            'accent_color' => $config['accent_color'] ?? 'primary',
             'padding' => $config['padding'] ?? 'py-16',
             'first_section' => $config['first_section'] ?? false,
             'anchor_id' => static::getAnchorId($config, $config['heading'] ?? null),

--- a/resources/views/cms/blocks/partials/timeline-content.blade.php
+++ b/resources/views/cms/blocks/partials/timeline-content.blade.php
@@ -6,7 +6,7 @@
     <div class="card-body p-5 sm:p-6">
         {{-- Date shown in content regardless of numbered mode (number only affects node display) --}}
         @if(!empty($item['date']))
-            <span class="inline-block text-xs font-semibold text-primary mb-2">
+            <span class="inline-block text-xs font-semibold @accent('text', $accent_color ?? 'primary') mb-2">
                 {{ $item['date'] }}
             </span>
         @endif

--- a/resources/views/cms/blocks/partials/timeline-node.blade.php
+++ b/resources/views/cms/blocks/partials/timeline-node.blade.php
@@ -1,19 +1,19 @@
 {{-- Timeline Node (circle with number, icon, or date) --}}
-<div class="w-12 h-12 sm:w-14 sm:h-14 rounded-full bg-primary/10 flex items-center justify-center ring-4 ring-base-100">
+<div class="w-12 h-12 sm:w-14 sm:h-14 rounded-full @accent('tint10', $accent_color ?? 'primary') flex items-center justify-center ring-4 ring-base-100">
     @if($isNumbered)
-        <span class="text-lg sm:text-xl font-bold text-primary">
+        <span class="text-lg sm:text-xl font-bold @accent('text', $accent_color ?? 'primary')">
             {{ $index + 1 }}
         </span>
     @elseif($isValidIcon)
         <x-dynamic-component
             :component="$iconName"
-            class="w-6 h-6 text-primary"
+            class="w-6 h-6 {{ \TallCms\Cms\Filament\Blocks\Support\AccentColor::text($accent_color ?? 'primary') }}"
         />
     @elseif(!empty($date))
-        <span class="text-xs font-semibold text-primary text-center leading-tight px-1 truncate w-full">
+        <span class="text-xs font-semibold @accent('text', $accent_color ?? 'primary') text-center leading-tight px-1 truncate w-full">
             {{ $date }}
         </span>
     @else
-        <div class="w-3 h-3 rounded-full bg-primary"></div>
+        <div class="w-3 h-3 rounded-full @accent('bg', $accent_color ?? 'primary')"></div>
     @endif
 </div>

--- a/resources/views/cms/blocks/pricing.blade.php
+++ b/resources/views/cms/blocks/pricing.blade.php
@@ -24,6 +24,10 @@
         'relaxed' => 'gap-8',
         default => 'gap-6'
     };
+
+    $accent = $accent_color ?? 'primary';
+    $accentTint5 = \TallCms\Cms\Filament\Blocks\Support\AccentColor::tint5($accent);
+    $accentBorder = \TallCms\Cms\Filament\Blocks\Support\AccentColor::border($accent);
 @endphp
 
 <section class="pricing-block {{ $sectionPadding }} {{ $background ?? 'bg-base-100' }}">
@@ -68,13 +72,13 @@
                         // Card classes using daisyUI
                         $cardClasses = match($card_style) {
                             'bordered' => $isPopular
-                                ? 'card bg-primary/5 border-2 border-primary'
+                                ? "card $accentTint5 border-2 $accentBorder"
                                 : 'card bg-base-100 border-2 border-base-300',
                             'elevated' => $isPopular
-                                ? 'card bg-primary/5 shadow-2xl scale-105 border-2 border-primary'
+                                ? "card $accentTint5 shadow-2xl scale-105 border-2 $accentBorder"
                                 : 'card bg-base-200 shadow-lg',
                             default => $isPopular
-                                ? 'card bg-primary/5 shadow-xl border-2 border-primary'
+                                ? "card $accentTint5 shadow-xl border-2 $accentBorder"
                                 : 'card bg-base-200 shadow-lg',
                         };
 

--- a/resources/views/cms/blocks/testimonials.blade.php
+++ b/resources/views/cms/blocks/testimonials.blade.php
@@ -40,7 +40,7 @@
                         <div class="{{ $styleClasses }} {{ !$loop->last ? 'mb-8' : '' }}">
                             <div class="card-body">
                                 @if($isQuoteMarks)
-                                    <div class="absolute top-4 left-6 text-6xl text-primary/20 font-serif leading-none">"</div>
+                                    <div class="absolute top-4 left-6 text-6xl @accent('text20', $accent_color ?? 'primary') font-serif leading-none">"</div>
                                 @endif
 
                                 {{-- Rating --}}
@@ -75,7 +75,7 @@
                                         </div>
                                     @else
                                         <div class="avatar placeholder">
-                                            <div class="w-14 rounded-full bg-primary/10 text-primary">
+                                            <div class="w-14 rounded-full @accent('tint10', $accent_color ?? 'primary') @accent('text', $accent_color ?? 'primary')">
                                                 <span class="text-xl font-semibold">
                                                     {{ substr($testimonial['author_name'] ?? 'A', 0, 1) }}
                                                 </span>
@@ -111,7 +111,7 @@
                         <div class="{{ $styleClasses }}">
                             <div class="card-body">
                                 @if($isQuoteMarks)
-                                    <div class="absolute top-4 left-6 text-5xl text-primary/20 font-serif leading-none">"</div>
+                                    <div class="absolute top-4 left-6 text-5xl @accent('text20', $accent_color ?? 'primary') font-serif leading-none">"</div>
                                 @endif
 
                                 {{-- Rating --}}
@@ -146,7 +146,7 @@
                                         </div>
                                     @else
                                         <div class="avatar placeholder">
-                                            <div class="w-10 rounded-full bg-primary/10 text-primary">
+                                            <div class="w-10 rounded-full @accent('tint10', $accent_color ?? 'primary') @accent('text', $accent_color ?? 'primary')">
                                                 <span class="text-sm font-semibold">
                                                     {{ substr($testimonial['author_name'] ?? 'A', 0, 1) }}
                                                 </span>

--- a/tests/Feature/Blocks/HowToBlockRenderTest.php
+++ b/tests/Feature/Blocks/HowToBlockRenderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Blocks;
+
+use TallCms\Cms\Filament\Blocks\HowToBlock;
+use Tests\TestCase;
+
+/**
+ * How-To block uses mode 1 (plain HTML <div>) on the step number circle.
+ * Migration replaced 'bg-primary text-primary-content' with
+ * @accent('fill', $accent_color ?? 'primary').
+ */
+class HowToBlockRenderTest extends TestCase
+{
+    private function sampleConfig(array $overrides = []): array
+    {
+        return array_merge([
+            'title' => 'Get Started',
+            'steps' => [[
+                'title' => 'Step 1',
+                'description' => 'Do this thing.',
+            ]],
+        ], $overrides);
+    }
+
+    public function test_default_step_circle_uses_primary_fill(): void
+    {
+        $html = HowToBlock::toHtml($this->sampleConfig(), []);
+        $this->assertStringContainsString('bg-primary text-primary-content', $html);
+    }
+
+    public function test_accent_recolors_step_circle(): void
+    {
+        $html = HowToBlock::toHtml($this->sampleConfig(['accent_color' => 'accent']), []);
+        $this->assertStringContainsString('bg-accent text-accent-content', $html);
+        $this->assertStringNotContainsString('bg-primary text-primary-content', $html);
+    }
+
+    public function test_warning_token_renders_warning_fill(): void
+    {
+        $html = HowToBlock::toHtml($this->sampleConfig(['accent_color' => 'warning']), []);
+        $this->assertStringContainsString('bg-warning text-warning-content', $html);
+    }
+}

--- a/tests/Feature/Blocks/PricingBlockRenderTest.php
+++ b/tests/Feature/Blocks/PricingBlockRenderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Blocks;
+
+use TallCms\Cms\Filament\Blocks\PricingBlock;
+use Tests\TestCase;
+
+/**
+ * Pricing block uses mode 2 — the popular-plan card class is built
+ * inside @php match() arms with precomputed $accentTint5 + $accentBorder.
+ * The @accent directive doesn't work in that scope.
+ */
+class PricingBlockRenderTest extends TestCase
+{
+    private function popularPlanConfig(array $overrides = []): array
+    {
+        return array_merge([
+            'section_title' => 'Pricing',
+            'plans' => [
+                [
+                    'plan_name' => 'Starter',
+                    'price' => '0',
+                    'is_popular' => false,
+                    'features' => [['text' => 'Basic', 'is_included' => true]],
+                ],
+                [
+                    'plan_name' => 'Pro',
+                    'price' => '29',
+                    'is_popular' => true,
+                    'features' => [['text' => 'Everything', 'is_included' => true]],
+                ],
+            ],
+        ], $overrides);
+    }
+
+    public function test_default_popular_card_uses_primary_tint_and_border(): void
+    {
+        $html = PricingBlock::toHtml($this->popularPlanConfig(), []);
+        $this->assertStringContainsString('bg-primary/5', $html);
+        $this->assertStringContainsString('border-primary', $html);
+    }
+
+    public function test_error_accent_recolors_popular_card(): void
+    {
+        $html = PricingBlock::toHtml($this->popularPlanConfig(['accent_color' => 'error']), []);
+        $this->assertStringContainsString('bg-error/5', $html);
+        $this->assertStringContainsString('border-error', $html);
+        $this->assertStringNotContainsString('bg-primary/5', $html);
+    }
+
+    public function test_non_popular_plan_unaffected_by_accent(): void
+    {
+        // The "Starter" plan is not popular — its card uses bg-base-100/200.
+        // Changing accent_color must not bleed into base-card classes.
+        $html = PricingBlock::toHtml($this->popularPlanConfig(['accent_color' => 'success']), []);
+        $this->assertStringContainsString('bg-success/5', $html, 'Popular card recolors');
+        $this->assertStringContainsString('bg-base-200', $html, 'Non-popular cards keep base-200');
+    }
+}

--- a/tests/Feature/Blocks/StatsBlockRenderTest.php
+++ b/tests/Feature/Blocks/StatsBlockRenderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Blocks;
+
+use TallCms\Cms\Filament\Blocks\StatsBlock;
+use Tests\TestCase;
+
+/**
+ * Stats block uses mode 1 (plain HTML <div>) on .stat-figure and .stat-value.
+ * Migration replaced text-primary with @accent('text', $accent_color ?? 'primary').
+ */
+class StatsBlockRenderTest extends TestCase
+{
+    private function sampleConfig(array $overrides = []): array
+    {
+        return array_merge([
+            'heading' => 'Test',
+            'stats' => [[
+                'icon' => 'heroicon-o-bolt',
+                'value' => '99',
+                'label' => 'Speed',
+            ]],
+        ], $overrides);
+    }
+
+    public function test_default_uses_primary_text(): void
+    {
+        $html = StatsBlock::toHtml($this->sampleConfig(), []);
+        $this->assertStringContainsString('text-primary', $html);
+    }
+
+    public function test_secondary_recolors_stat_figure_and_value(): void
+    {
+        $html = StatsBlock::toHtml($this->sampleConfig(['accent_color' => 'secondary']), []);
+        $this->assertStringContainsString('stat-figure text-secondary', $html);
+        $this->assertStringContainsString('stat-value text-secondary', $html);
+    }
+
+    public function test_unknown_accent_falls_back_to_primary(): void
+    {
+        $html = StatsBlock::toHtml($this->sampleConfig(['accent_color' => 'made-up']), []);
+        $this->assertStringContainsString('stat-figure text-primary', $html);
+    }
+}

--- a/tests/Feature/Blocks/TestimonialsBlockRenderTest.php
+++ b/tests/Feature/Blocks/TestimonialsBlockRenderTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Blocks;
+
+use TallCms\Cms\Filament\Blocks\TestimonialsBlock;
+use Tests\TestCase;
+
+/**
+ * Testimonials block uses mode 1 (plain HTML <div>) for both the quote
+ * marks (text20 variant) and the avatar wrap (tint10 + text variants).
+ * The Elevate theme's gradient quote marks (text-gradient-primary) are
+ * intentionally unchanged — that's a theme-decoration design call.
+ */
+class TestimonialsBlockRenderTest extends TestCase
+{
+    private function sampleConfig(array $overrides = []): array
+    {
+        return array_merge([
+            'heading' => 'Reviews',
+            // 'quote-marks' substring triggers $isQuoteMarks in the view.
+            'card_style' => 'card bg-base-200 quote-marks',
+            'testimonials' => [[
+                'author_name' => 'Alice',
+                'quote' => 'Great product.',
+                'rating' => 5,
+            ]],
+        ], $overrides);
+    }
+
+    public function test_default_quote_mark_uses_primary20(): void
+    {
+        $html = TestimonialsBlock::toHtml($this->sampleConfig(), []);
+        $this->assertStringContainsString('text-primary/20', $html);
+    }
+
+    public function test_default_avatar_wrap_uses_primary_tint10_and_text(): void
+    {
+        $html = TestimonialsBlock::toHtml($this->sampleConfig(), []);
+        $this->assertStringContainsString('bg-primary/10', $html);
+        $this->assertStringContainsString('text-primary', $html);
+    }
+
+    public function test_info_accent_recolors_quote_marks_and_avatar(): void
+    {
+        $html = TestimonialsBlock::toHtml($this->sampleConfig(['accent_color' => 'info']), []);
+        $this->assertStringContainsString('text-info/20', $html);
+        $this->assertStringContainsString('bg-info/10', $html);
+        $this->assertStringContainsString('text-info', $html);
+    }
+}

--- a/tests/Feature/Blocks/TimelineBlockRenderTest.php
+++ b/tests/Feature/Blocks/TimelineBlockRenderTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Blocks;
+
+use TallCms\Cms\Filament\Blocks\TimelineBlock;
+use Tests\TestCase;
+
+/**
+ * Timeline block delegates rendering to two partials:
+ *
+ *   - timeline-node.blade.php — modes 1 + 3 (icon class is inside
+ *     <x-dynamic-component>, so uses inline FQCN).
+ *   - timeline-content.blade.php — mode 1.
+ *
+ * Tests exercise the numbered branch (mode 1) and the icon branch
+ * (mode 3) plus the date label in timeline-content.
+ */
+class TimelineBlockRenderTest extends TestCase
+{
+    private function numberedConfig(array $overrides = []): array
+    {
+        return array_merge([
+            'heading' => 'History',
+            'numbered' => true,
+            'items' => [[
+                'title' => 'First',
+                'description' => 'desc',
+                'date' => '2024',
+            ]],
+        ], $overrides);
+    }
+
+    public function test_default_numbered_node_uses_primary_text_and_tint(): void
+    {
+        $html = TimelineBlock::toHtml($this->numberedConfig(), []);
+        $this->assertStringContainsString('bg-primary/10', $html);
+        $this->assertStringContainsString('text-primary', $html);
+    }
+
+    public function test_success_accent_recolors_node_ring_and_number(): void
+    {
+        $html = TimelineBlock::toHtml($this->numberedConfig(['accent_color' => 'success']), []);
+        $this->assertStringContainsString('bg-success/10', $html);
+        $this->assertStringContainsString('text-success', $html);
+    }
+
+    public function test_date_label_in_content_partial_picks_up_accent(): void
+    {
+        // Date label lives in timeline-content.blade.php — separate partial.
+        $html = TimelineBlock::toHtml($this->numberedConfig(['accent_color' => 'warning']), []);
+        $this->assertStringContainsString('text-warning', $html);
+    }
+}


### PR DESCRIPTION
## Summary

Migrates the remaining five hotspot blocks (Stats, How-To, Testimonials, Timeline, Pricing) to the `accent_color` knob added in #72. Each block now lets editors pick which daisyUI semantic token (primary, secondary, accent, neutral, info, success, warning, error) drives the icons / quote marks / step circles / timeline nodes / popular plan highlights — instead of every block always rendering primary.

22 files changed: 5 PHP block schemas, 12 Blade views (package canonical + Elevate package source + standalone overrides), 5 new render tests.

Closes the duotone problem this work set out to fix: themes with rich palettes (the new `tallcms` brand theme being the trigger) can now express the full palette across blocks instead of stopping at primary + base.

## Per-view consumption modes

All three Blade consumption modes from #72 are exercised:

| Block | Mode 1 (plain `class=`) | Mode 2 (`@php`-built) | Mode 3 (`<x-...>` attr) |
|---|---|---|---|
| Stats | text ×2 | — | — |
| How-To | fill ×1 | — | — |
| Testimonials | text20, tint10, text — package ×4, standalone ×4, elevate ×2 | — | — |
| Timeline | tint10, text, bg in `partials/timeline-node` + text in `partials/timeline-content` | — | text (inside `<x-dynamic-component>` in timeline-node) |
| Pricing | — | tint5, border (precomputed `$accentTint5` + `$accentBorder` in package + standalone); + shadow10 (`$accentShadow10`) in elevate | text (inside `<x-heroicon-s-check>` in elevate) |

## Intentionally unchanged

- **Elevate testimonials** quote marks at lines 83 / 168 use a custom `text-gradient-primary` utility (theme-specific gradient text). The avatar wraps on the same view (lines 119 / 204) **do** track `accent_color`.
- **Elevate features** icon container gradient (`bg-gradient-to-br from-primary/10 to-secondary/10`) — already called out in #72.

## Test plan

- [x] `php artisan test --filter='StatsBlock|HowToBlock|TestimonialsBlock|TimelineBlock|PricingBlock|FeaturesBlock'` green (25 tests, 44 assertions — locally green).
- [x] `cd themes/tallcms && NODE_PATH=../../node_modules npx vite build` and grep the compiled CSS for `text-success-content`, `bg-warning text-warning-content` (separated), `text-info\/20`, `shadow-error\/10`, `bg-success\/5`, `border-error` — all should be present (locally verified).
- [ ] In the admin, edit one block of each migrated type, set `accent_color` to non-primary, view the frontend. Specifically:
  - Stats: stat icon + value recolor.
  - How-To: step number circles recolor.
  - Testimonials: quote marks (faded) + avatar wrap recolor.
  - Timeline: numbered/icon/date/dot node markers recolor; date label in content card recolors.
  - Pricing: popular plan card border + tint recolor (Elevate also picks up the shadow).
- [ ] Set `accent_color` back to `primary` (or unset) on each block — confirm pixel-identical to pre-PR render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)