### PR TITLE
Add badge() variant to AccentColor (prerequisite for Pro sweep)

### DIFF
--- a/packages/tallcms/cms/src/Filament/Blocks/Support/AccentColor.php
+++ b/packages/tallcms/cms/src/Filament/Blocks/Support/AccentColor.php
@@ -129,6 +129,20 @@ class AccentColor
         };
     }
 
+    public static function badge(string $token = 'primary'): string
+    {
+        return match ($token) {
+            'secondary' => 'badge-secondary',
+            'accent' => 'badge-accent',
+            'neutral' => 'badge-neutral',
+            'info' => 'badge-info',
+            'success' => 'badge-success',
+            'warning' => 'badge-warning',
+            'error' => 'badge-error',
+            default => 'badge-primary',
+        };
+    }
+
     /**
      * Dispatch by variant key. Used by the @accent Blade directive.
      * Unknown variants fall through to text() (defensive against typos).
@@ -143,6 +157,7 @@ class AccentColor
             'bg' => self::bg($token),
             'border' => self::border($token),
             'shadow10' => self::shadow10($token),
+            'badge' => self::badge($token),
             default => self::text($token),
         };
     }

--- a/packages/tallcms/cms/tests/Feature/AccentColorDirectiveTest.php
+++ b/packages/tallcms/cms/tests/Feature/AccentColorDirectiveTest.php
@@ -61,6 +61,14 @@ class AccentColorDirectiveTest extends TestCase
         );
     }
 
+    public function test_directive_emits_badge_class(): void
+    {
+        $this->assertSame(
+            'badge-success',
+            Blade::render("@accent('badge', 'success')")
+        );
+    }
+
     public function test_directive_emits_text20_class(): void
     {
         $this->assertSame(

--- a/packages/tallcms/cms/tests/Unit/AccentColorTest.php
+++ b/packages/tallcms/cms/tests/Unit/AccentColorTest.php
@@ -91,6 +91,16 @@ class AccentColorTest extends TestCase
             ['shadow10', 'success', 'shadow-success/10'],
             ['shadow10', 'warning', 'shadow-warning/10'],
             ['shadow10', 'error', 'shadow-error/10'],
+
+            // badge (daisyUI badge-* modifier)
+            ['badge', 'primary', 'badge-primary'],
+            ['badge', 'secondary', 'badge-secondary'],
+            ['badge', 'accent', 'badge-accent'],
+            ['badge', 'neutral', 'badge-neutral'],
+            ['badge', 'info', 'badge-info'],
+            ['badge', 'success', 'badge-success'],
+            ['badge', 'warning', 'badge-warning'],
+            ['badge', 'error', 'badge-error'],
         ];
     }
 
@@ -117,6 +127,7 @@ class AccentColorTest extends TestCase
         $this->assertSame('bg-primary/10', AccentColor::tint10('typo'));
         $this->assertSame('bg-primary text-primary-content', AccentColor::fill(''));
         $this->assertSame('shadow-primary/10', AccentColor::shadow10('garbage'));
+        $this->assertSame('badge-primary', AccentColor::badge('made-up'));
     }
 
     public function test_unknown_variant_in_resolve_falls_back_to_text(): void


### PR DESCRIPTION
## Summary

Adds `AccentColor::badge()` and the `badge` variant key to `resolve()`, so `@accent('badge', \$token)` emits daisyUI's `badge-primary` / `badge-secondary` / etc. modifier classes. 8 new literal class strings, no other behaviour changes.

## Why

The Pro plugin's Accordion and Comparison blocks use the daisyUI `badge-*` modifier on featured/active markers. The existing 8 `AccentColor` variants (text, text20, tint5, tint10, fill, bg, border, shadow10) don't cover that pattern, so the upcoming Pro sweep can't migrate those locations until this lands.

This is a **prerequisite for the Pro plugin sweep** — that PR will pin its `compatibility.tallcms` floor to whatever version this lands in, so this should be tagged before the Pro PR merges.

## Suggested release

Recommend tagging \`tallcms/cms\` \`4.4.0\` after merge — minor bump for new helper variant, matches the floor the Pro plugin will pin to.

## Test plan

- [x] \`cd packages/tallcms/cms && vendor/bin/phpunit --filter=AccentColor\` — 158 tests pass (up from 141; +17 new badge assertions).
- [ ] Build a theme that scans the helper file and grep the bundle for \`.badge-secondary\`, \`.badge-info\`, \`.badge-error\`, etc. — all 8 should be present (extracted from the new match arms via the existing \`@source ".../Filament/Blocks/**/*.php"\` directive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)