### PR TITLE
Add render tests for Pro plugin Tabs and Table blocks

### DIFF
--- a/tests/Feature/Blocks/ProTableBlockRenderTest.php
+++ b/tests/Feature/Blocks/ProTableBlockRenderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Blocks;
+
+use Tallcms\Pro\Blocks\TableBlock;
+use Tests\TestCase;
+
+/**
+ * Render tests for the Pro plugin's Table block.
+ *
+ * The row-highlight tint uses mode 2 (precomputed $accentTint10
+ * inside @php) — that single variable serves both a plain <tr>
+ * (mode 1) and a <tallcms::animation-wrapper> tag attribute
+ * (mode 3) without separate computation. See tallcms-pro-plugin#1.
+ */
+class ProTableBlockRenderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! class_exists(TableBlock::class)) {
+            $this->markTestSkipped('Pro plugin not installed.');
+        }
+    }
+
+    private function sampleConfig(array $overrides = []): array
+    {
+        return array_merge([
+            'headers' => [
+                ['label' => 'Feature', 'align' => 'left'],
+                ['label' => 'Value', 'align' => 'right'],
+            ],
+            'rows' => [
+                [
+                    'cells' => [['value' => 'Speed'], ['value' => 'Fast']],
+                    'highlight' => false,
+                ],
+                [
+                    'cells' => [['value' => 'Best'], ['value' => 'Yes']],
+                    'highlight' => true,
+                ],
+            ],
+        ], $overrides);
+    }
+
+    public function test_default_highlighted_row_uses_primary_tint(): void
+    {
+        $html = TableBlock::toHtml($this->sampleConfig(), []);
+        $this->assertStringContainsString('bg-primary/10', $html);
+    }
+
+    public function test_info_accent_recolors_highlighted_row(): void
+    {
+        $html = TableBlock::toHtml($this->sampleConfig(['accent_color' => 'info']), []);
+        $this->assertStringContainsString('bg-info/10', $html);
+        $this->assertStringNotContainsString('bg-primary/10', $html);
+    }
+
+    public function test_non_highlighted_rows_unaffected_by_accent(): void
+    {
+        $config = $this->sampleConfig([
+            'accent_color' => 'warning',
+            'rows' => [
+                ['cells' => [['value' => 'A']], 'highlight' => false],
+                ['cells' => [['value' => 'B']], 'highlight' => false],
+            ],
+        ]);
+        $html = TableBlock::toHtml($config, []);
+        $this->assertStringNotContainsString('bg-warning/10', $html);
+    }
+
+    public function test_unknown_accent_falls_back_to_primary(): void
+    {
+        $html = TableBlock::toHtml($this->sampleConfig(['accent_color' => 'made-up']), []);
+        $this->assertStringContainsString('bg-primary/10', $html);
+    }
+}

--- a/tests/Feature/Blocks/ProTabsBlockRenderTest.php
+++ b/tests/Feature/Blocks/ProTabsBlockRenderTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Blocks;
+
+use Tallcms\Pro\Blocks\TabsBlock;
+use Tests\TestCase;
+
+/**
+ * Render tests for the Pro plugin's Tabs block.
+ *
+ * Lives in tallcms standalone (not the Pro plugin repo) because Pro
+ * has no phpunit infra of its own and rendering needs heroicons,
+ * which only bootstrap properly in the parent app.
+ *
+ * The TabsBlock active-indicator uses mode 2 (precomputed
+ * $accentBorder + $accentFill inside @php match() arms) — see
+ * tallcms-pro-plugin#1.
+ */
+class ProTabsBlockRenderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! class_exists(TabsBlock::class)) {
+            $this->markTestSkipped('Pro plugin not installed.');
+        }
+    }
+
+    private function sampleConfig(array $overrides = []): array
+    {
+        return array_merge([
+            'heading' => 'Tabs',
+            'tabs' => [
+                ['title' => 'Tab 1', 'content' => 'First tab'],
+                ['title' => 'Tab 2', 'content' => 'Second tab'],
+            ],
+            'active_indicator' => 'underline',
+        ], $overrides);
+    }
+
+    public function test_default_underline_uses_primary_border(): void
+    {
+        $html = TabsBlock::toHtml($this->sampleConfig(), []);
+        $this->assertStringContainsString('border-primary', $html);
+    }
+
+    public function test_secondary_accent_recolors_underline(): void
+    {
+        $html = TabsBlock::toHtml($this->sampleConfig(['accent_color' => 'secondary']), []);
+        $this->assertStringContainsString('border-secondary', $html);
+        $this->assertStringNotContainsString('border-primary', $html);
+    }
+
+    public function test_filled_indicator_uses_fill_variant(): void
+    {
+        $config = $this->sampleConfig([
+            'active_indicator' => 'filled',
+            'accent_color' => 'success',
+        ]);
+        $html = TabsBlock::toHtml($config, []);
+        $this->assertStringContainsString('bg-success', $html);
+        $this->assertStringContainsString('text-success-content', $html);
+    }
+
+    public function test_default_indicator_emits_no_accent_class(): void
+    {
+        // 'default' indicator falls through to '' regardless of accent_color
+        $config = $this->sampleConfig([
+            'active_indicator' => 'default',
+            'accent_color' => 'error',
+        ]);
+        $html = TabsBlock::toHtml($config, []);
+        $this->assertStringNotContainsString('border-error', $html);
+        $this->assertStringNotContainsString('bg-error text-error-content', $html);
+    }
+
+    public function test_unknown_accent_falls_back_to_primary(): void
+    {
+        $html = TabsBlock::toHtml($this->sampleConfig(['accent_color' => 'made-up']), []);
+        $this->assertStringContainsString('border-primary', $html);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to tallcms-pro-plugin#1 (Pro v1.9.0). Adds end-to-end render tests for the new \`accent_color\` knob on TabsBlock and TableBlock.

These tests live here (not in the Pro plugin repo) for the same reason FeaturesBlock render tests landed in this suite back in #72: Pro has no phpunit infra of its own, and rendering needs blade-ui-kit/blade-heroicons which only bootstraps cleanly in the parent app.

## What's covered

**ProTabsBlockRenderTest** — 5 tests:
- Default \`underline\` indicator uses \`border-primary\`.
- \`accent_color: secondary\` recolors the underline to \`border-secondary\`; primary border is gone.
- \`active_indicator: filled\` + \`accent_color: success\` produces \`bg-success\` + \`text-success-content\` (the fill variant).
- \`active_indicator: default\` emits **no** accent class regardless of accent_color (the empty-string match arm is preserved).
- Unknown accent token falls back to primary.

**ProTableBlockRenderTest** — 4 tests:
- Default highlighted row uses \`bg-primary/10\`.
- \`accent_color: info\` swaps highlighted rows to \`bg-info/10\`; primary tint is gone.
- **Non-highlighted rows are unaffected** by the accent setting (this is the important regression guard — the precomputed \`\$accentTint10\` in the view sits behind a per-row conditional and must not bleed).
- Unknown accent token falls back to primary.

Both files guard with \`markTestSkipped\` if the Pro plugin classes aren't loaded, matching the existing \`ProFeaturesTest\` pattern.

## Test plan

- [x] \`php artisan test --filter='ProTabsBlock|ProTableBlock'\` — 9 tests pass, 13 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)