### PR TITLE
Fix tenant-data leak in admin resource list queries

### DIFF
--- a/packages/tallcms/cms/src/Filament/Resources/CmsCategories/CmsCategoryResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsCategories/CmsCategoryResource.php
@@ -13,10 +13,12 @@ use TallCms\Cms\Filament\Resources\CmsCategories\Pages\EditCmsCategory;
 use TallCms\Cms\Filament\Resources\CmsCategories\Pages\ListCmsCategories;
 use TallCms\Cms\Filament\Resources\CmsCategories\Schemas\CmsCategoryForm;
 use TallCms\Cms\Filament\Resources\CmsCategories\Tables\CmsCategoriesTable;
+use TallCms\Cms\Filament\Resources\Concerns\ScopesQueryToOwnedSites;
 use TallCms\Cms\Models\CmsCategory;
 
 class CmsCategoryResource extends Resource
 {
+    use ScopesQueryToOwnedSites;
     use Translatable;
 
     protected static ?string $model = CmsCategory::class;
@@ -84,13 +86,7 @@ class CmsCategoryResource extends Resource
                 SoftDeletingScope::class,
             ]);
 
-        // User-owned: non-super-admins see only their own categories
-        if (auth()->check() && ! auth()->user()->hasRole('super_admin')
-            && \Illuminate\Support\Facades\Schema::hasColumn('tallcms_categories', 'user_id')) {
-            $query->where('tallcms_categories.user_id', auth()->id());
-        }
-
-        return $query;
+        return static::scopeQueryToOwnedTenants($query);
     }
 
     public static function getNavigationBadge(): ?string

--- a/packages/tallcms/cms/src/Filament/Resources/CmsPages/CmsPageResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsPages/CmsPageResource.php
@@ -14,10 +14,12 @@ use TallCms\Cms\Filament\Resources\CmsPages\Pages\EditCmsPage;
 use TallCms\Cms\Filament\Resources\CmsPages\Pages\ListCmsPages;
 use TallCms\Cms\Filament\Resources\CmsPages\Schemas\CmsPageForm;
 use TallCms\Cms\Filament\Resources\CmsPages\Tables\CmsPagesTable;
+use TallCms\Cms\Filament\Resources\Concerns\ScopesQueryToOwnedSites;
 use TallCms\Cms\Models\CmsPage;
 
 class CmsPageResource extends Resource
 {
+    use ScopesQueryToOwnedSites;
     use Translatable;
 
     protected static ?string $model = CmsPage::class;
@@ -56,10 +58,12 @@ class CmsPageResource extends Resource
 
     public static function getEloquentQuery(): Builder
     {
-        return parent::getEloquentQuery()
+        $query = parent::getEloquentQuery()
             ->withoutGlobalScopes([
                 SoftDeletingScope::class,
             ]);
+
+        return static::scopeQueryToOwnedSites($query);
     }
 
     public static function shouldRegisterNavigation(): bool

--- a/packages/tallcms/cms/src/Filament/Resources/CmsPosts/CmsPostResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsPosts/CmsPostResource.php
@@ -14,10 +14,12 @@ use TallCms\Cms\Filament\Resources\CmsPosts\Pages\EditCmsPost;
 use TallCms\Cms\Filament\Resources\CmsPosts\Pages\ListCmsPosts;
 use TallCms\Cms\Filament\Resources\CmsPosts\Schemas\CmsPostForm;
 use TallCms\Cms\Filament\Resources\CmsPosts\Tables\CmsPostsTable;
+use TallCms\Cms\Filament\Resources\Concerns\ScopesQueryToOwnedSites;
 use TallCms\Cms\Models\CmsPost;
 
 class CmsPostResource extends Resource
 {
+    use ScopesQueryToOwnedSites;
     use Translatable;
 
     protected static ?string $model = CmsPost::class;
@@ -91,13 +93,7 @@ class CmsPostResource extends Resource
                 SoftDeletingScope::class,
             ]);
 
-        // User-owned: non-super-admins see only their own posts
-        if (auth()->check() && ! auth()->user()->hasRole('super_admin')
-            && \Illuminate\Support\Facades\Schema::hasColumn('tallcms_posts', 'user_id')) {
-            $query->where('tallcms_posts.user_id', auth()->id());
-        }
-
-        return $query;
+        return static::scopeQueryToOwnedTenants($query);
     }
 
     public static function getNavigationBadge(): ?string

--- a/packages/tallcms/cms/src/Filament/Resources/Concerns/ScopesQueryToOwnedSites.php
+++ b/packages/tallcms/cms/src/Filament/Resources/Concerns/ScopesQueryToOwnedSites.php
@@ -36,6 +36,15 @@ trait ScopesQueryToOwnedSites
             return $query;
         }
 
+        // Gate on the multisite plugin actually being booted, not just the
+        // presence of a site_id column. If multisite was uninstalled or
+        // disabled but the columns/tables linger, schema-only detection would
+        // leave normal admins filtered to zero rows against a stale
+        // tallcms_sites table.
+        if (! function_exists('tallcms_multisite_active') || ! tallcms_multisite_active()) {
+            return $query;
+        }
+
         $table = $query->getModel()->getTable();
         if (! Schema::hasColumn($table, 'site_id')) {
             return $query;
@@ -50,6 +59,55 @@ trait ScopesQueryToOwnedSites
             return $query;
         }
 
-        return $query->whereIn('site_id', $ownedSiteIds);
+        return $query->whereIn($table.'.site_id', $ownedSiteIds);
+    }
+
+    /**
+     * Like scopeQueryToOwnedSites, but falls back to filtering by user_id
+     * (record creator) when the table has no site_id column.
+     *
+     * Use this for resources that exist in both multisite and standalone:
+     *   - multisite install (site_id present) → scope by owned sites
+     *   - standalone install (site_id absent, user_id present) → scope by creator
+     *   - super_admin → bypass either way
+     *
+     * scopeQueryToOwnedSites is a no-op in standalone, which is correct for
+     * resources that have no per-user notion of ownership outside multisite
+     * (Pages, Menus, Comments, Contact Submissions). For Posts/Categories/Media,
+     * the prior single-site behavior was a per-creator filter — this helper
+     * preserves it.
+     */
+    protected static function scopeQueryToOwnedTenants(Builder $query): Builder
+    {
+        $user = auth()->user();
+
+        if (! $user) {
+            return $query;
+        }
+
+        if (method_exists($user, 'hasRole') && $user->hasRole('super_admin')) {
+            return $query;
+        }
+
+        $table = $query->getModel()->getTable();
+        $multisiteActive = function_exists('tallcms_multisite_active') && tallcms_multisite_active();
+
+        try {
+            if ($multisiteActive && Schema::hasColumn($table, 'site_id')) {
+                $ownedSiteIds = DB::table('tallcms_sites')
+                    ->where('user_id', $user->getAuthIdentifier())
+                    ->pluck('id');
+
+                return $query->whereIn($table.'.site_id', $ownedSiteIds);
+            }
+
+            if (Schema::hasColumn($table, 'user_id')) {
+                return $query->where($table.'.user_id', $user->getAuthIdentifier());
+            }
+        } catch (\Throwable) {
+            // Schema not yet migrated; fall through to unfiltered query.
+        }
+
+        return $query;
     }
 }

--- a/packages/tallcms/cms/src/Filament/Resources/MediaCollection/MediaCollectionResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/MediaCollection/MediaCollectionResource.php
@@ -15,6 +15,7 @@ use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\ColorColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use TallCms\Cms\Filament\Resources\Concerns\ScopesQueryToOwnedSites;
 use TallCms\Cms\Filament\Resources\MediaCollection\Pages\CreateMediaCollection;
 use TallCms\Cms\Filament\Resources\MediaCollection\Pages\EditMediaCollection;
 use TallCms\Cms\Filament\Resources\MediaCollection\Pages\ListMediaCollections;
@@ -23,6 +24,8 @@ use TallCms\Cms\Rules\UserAwareUnique;
 
 class MediaCollectionResource extends Resource
 {
+    use ScopesQueryToOwnedSites;
+
     protected static ?string $model = MediaCollection::class;
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedFolderOpen;
@@ -137,15 +140,7 @@ class MediaCollectionResource extends Resource
 
     public static function getEloquentQuery(): \Illuminate\Database\Eloquent\Builder
     {
-        $query = parent::getEloquentQuery();
-
-        // User-owned: non-super-admins see only their own collections
-        if (auth()->check() && ! auth()->user()->hasRole('super_admin')
-            && \Illuminate\Support\Facades\Schema::hasColumn('tallcms_media_collections', 'user_id')) {
-            $query->where('tallcms_media_collections.user_id', auth()->id());
-        }
-
-        return $query;
+        return static::scopeQueryToOwnedTenants(parent::getEloquentQuery());
     }
 
     public static function getPages(): array

--- a/packages/tallcms/cms/src/Filament/Resources/TallcmsMedia/TallcmsMediaResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/TallcmsMedia/TallcmsMediaResource.php
@@ -8,6 +8,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use TallCms\Cms\Filament\Resources\Concerns\ScopesQueryToOwnedSites;
 use TallCms\Cms\Filament\Resources\TallcmsMedia\Pages\CreateTallcmsMedia;
 use TallCms\Cms\Filament\Resources\TallcmsMedia\Pages\EditTallcmsMedia;
 use TallCms\Cms\Filament\Resources\TallcmsMedia\Pages\ListTallcmsMedia;
@@ -17,6 +18,8 @@ use TallCms\Cms\Models\TallcmsMedia;
 
 class TallcmsMediaResource extends Resource
 {
+    use ScopesQueryToOwnedSites;
+
     protected static ?string $model = TallcmsMedia::class;
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
@@ -65,15 +68,7 @@ class TallcmsMediaResource extends Resource
 
     public static function getEloquentQuery(): Builder
     {
-        $query = parent::getEloquentQuery();
-
-        // User-owned: non-super-admins see only their own media
-        if (auth()->check() && ! auth()->user()->hasRole('super_admin')
-            && \Illuminate\Support\Facades\Schema::hasColumn('tallcms_media', 'user_id')) {
-            $query->where('tallcms_media.user_id', auth()->id());
-        }
-
-        return $query;
+        return static::scopeQueryToOwnedTenants(parent::getEloquentQuery());
     }
 
     public static function getPages(): array

--- a/packages/tallcms/cms/src/Filament/Resources/TallcmsMenus/TallcmsMenuResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/TallcmsMenus/TallcmsMenuResource.php
@@ -7,6 +7,8 @@ use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use TallCms\Cms\Filament\Resources\Concerns\ScopesQueryToOwnedSites;
 use TallCms\Cms\Filament\Resources\TallcmsMenus\Pages\CreateTallcmsMenu;
 use TallCms\Cms\Filament\Resources\TallcmsMenus\Pages\EditTallcmsMenu;
 use TallCms\Cms\Filament\Resources\TallcmsMenus\Pages\ListTallcmsMenus;
@@ -16,6 +18,8 @@ use TallCms\Cms\Models\TallcmsMenu;
 
 class TallcmsMenuResource extends Resource
 {
+    use ScopesQueryToOwnedSites;
+
     protected static ?string $model = TallcmsMenu::class;
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
@@ -81,5 +85,10 @@ class TallcmsMenuResource extends Resource
             'create' => CreateTallcmsMenu::route('/create'),
             'edit' => EditTallcmsMenu::route('/{record}/edit'),
         ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return static::scopeQueryToOwnedSites(parent::getEloquentQuery());
     }
 }

--- a/packages/tallcms/cms/tests/Fixtures/FakeMultisiteSiteScope.php
+++ b/packages/tallcms/cms/tests/Fixtures/FakeMultisiteSiteScope.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Test-only stub of the multisite plugin's SiteScope class. Lives in a
+ * bracketed namespace so PHP registers the class at exactly
+ * Tallcms\Multisite\Scopes\SiteScope — the FQN that
+ * tallcms_multisite_active() probes via class_exists() and
+ * CmsPage::hasGlobalScope().
+ *
+ * Loaded by ScopesQueryToOwnedSitesTest to flip the helper into
+ * "multisite is active" for those tests, without depending on the actual
+ * multisite plugin being installed in the cms package's composer tree.
+ */
+namespace Tallcms\Multisite\Scopes {
+    use Illuminate\Database\Eloquent\Builder;
+    use Illuminate\Database\Eloquent\Model;
+    use Illuminate\Database\Eloquent\Scope;
+
+    if (! class_exists(SiteScope::class, false)) {
+        class SiteScope implements Scope
+        {
+            public function apply(Builder $builder, Model $model): void
+            {
+                // Test stub — no-op. The real plugin's SiteScope filters
+                // by current frontend site; in tests we only need the
+                // class to exist + be registered as a global scope.
+            }
+        }
+    }
+}

--- a/packages/tallcms/cms/tests/Unit/ScopesQueryToOwnedSitesTest.php
+++ b/packages/tallcms/cms/tests/Unit/ScopesQueryToOwnedSitesTest.php
@@ -1,0 +1,419 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TallCms\Cms\Tests\Unit;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use TallCms\Cms\Filament\Resources\CmsPages\CmsPageResource;
+use TallCms\Cms\Filament\Resources\Concerns\ScopesQueryToOwnedSites;
+use TallCms\Cms\Models\CmsPage;
+use TallCms\Cms\Tests\TestCase;
+
+/**
+ * Covers the tenant-isolation predicate that all site-owned Filament resources
+ * use to filter their list queries. The trait is the single chokepoint for
+ * CmsPage, TallcmsMenu, CmsPost, CmsCategory, MediaCollection, TallcmsMedia,
+ * CmsComment, and TallcmsContactSubmission — testing it directly covers the
+ * cross-resource invariant.
+ *
+ * Plus one integration-flavored case on CmsPageResource itself to catch
+ * regressions where the resource forgets to delegate to the trait.
+ */
+class ScopesQueryToOwnedSitesTest extends TestCase
+{
+    protected function defineDatabaseMigrations(): void
+    {
+        parent::defineDatabaseMigrations();
+
+        Schema::create('tallcms_sites', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        // Multisite-shape table (has site_id).
+        Schema::create('multisite_records', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('site_id');
+            $table->string('label');
+            $table->timestamps();
+        });
+
+        // Standalone-shape table (only user_id).
+        Schema::create('single_site_records', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->string('label');
+            $table->timestamps();
+        });
+
+        // No tenancy column at all.
+        Schema::create('global_records', function (Blueprint $table) {
+            $table->id();
+            $table->string('label');
+            $table->timestamps();
+        });
+
+        // Real CmsPage table with site_id (mimics post-multisite-migration shape).
+        Schema::create('tallcms_pages', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('site_id')->nullable();
+            $table->json('title');
+            $table->json('slug');
+            $table->json('content')->nullable();
+            $table->text('search_content')->nullable();
+            $table->json('meta_title')->nullable();
+            $table->json('meta_description')->nullable();
+            $table->string('featured_image')->nullable();
+            $table->string('status')->default('draft');
+            $table->boolean('is_homepage')->default(false);
+            $table->unsignedBigInteger('parent_id')->nullable();
+            $table->integer('sort_order')->default(0);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Make tallcms_multisite_active() return true for tests that exercise
+     * the multisite scoping path. The helper checks
+     *   class_exists('Tallcms\Multisite\Scopes\SiteScope')
+     *     && CmsPage::hasGlobalScope('Tallcms\Multisite\Scopes\SiteScope')
+     * — we satisfy both by loading a fixture file that declares the class
+     * at the expected namespace and registering it on CmsPage.
+     */
+    protected function activateFakeMultisite(): void
+    {
+        require_once __DIR__.'/../Fixtures/FakeMultisiteSiteScope.php';
+        CmsPage::addGlobalScope(new \Tallcms\Multisite\Scopes\SiteScope);
+    }
+
+    protected function tearDown(): void
+    {
+        // Strip the fake scope so other tests in the suite don't inherit
+        // multisite-active state via Eloquent's static scopes registry.
+        if (class_exists(\Tallcms\Multisite\Scopes\SiteScope::class, false)) {
+            $ref = new \ReflectionProperty(\Illuminate\Database\Eloquent\Model::class, 'globalScopes');
+            $scopes = $ref->getValue();
+            unset($scopes[CmsPage::class][\Tallcms\Multisite\Scopes\SiteScope::class]);
+            $ref->setValue(null, $scopes);
+        }
+
+        parent::tearDown();
+    }
+
+    private function makeUser(string $name, bool $superAdmin = false): ScopingTestUser
+    {
+        $user = new ScopingTestUser;
+        $user->name = $name;
+        $user->email = "{$name}@test.local";
+        $user->password = 'x';
+        $user->isSuperAdmin = $superAdmin;
+        $user->save();
+
+        return $user;
+    }
+
+    public function test_unauthenticated_query_is_unfiltered(): void
+    {
+        DB::table('multisite_records')->insert([
+            ['site_id' => 1, 'label' => 'a', 'created_at' => now(), 'updated_at' => now()],
+            ['site_id' => 2, 'label' => 'b', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        $this->assertCount(2, MultisiteScopedHost::scope(MultisiteRecord::query())->get());
+    }
+
+    public function test_super_admin_sees_every_record(): void
+    {
+        $this->activateFakeMultisite();
+        $admin = $this->makeUser('admin', superAdmin: true);
+        $this->actingAs($admin);
+
+        DB::table('tallcms_sites')->insert([
+            ['id' => 10, 'user_id' => 999, 'name' => 'Other'],
+        ]);
+        DB::table('multisite_records')->insert([
+            ['site_id' => 10, 'label' => 'a', 'created_at' => now(), 'updated_at' => now()],
+            ['site_id' => 11, 'label' => 'b', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        $this->assertCount(2, MultisiteScopedHost::scope(MultisiteRecord::query())->get());
+    }
+
+    public function test_owner_only_sees_records_on_their_sites(): void
+    {
+        $this->activateFakeMultisite();
+        $owner = $this->makeUser('owner');
+        $other = $this->makeUser('other');
+        $this->actingAs($owner);
+
+        DB::table('tallcms_sites')->insert([
+            ['id' => 10, 'user_id' => $owner->id, 'name' => 'Owner Site'],
+            ['id' => 20, 'user_id' => $other->id, 'name' => 'Other Site'],
+        ]);
+        DB::table('multisite_records')->insert([
+            ['site_id' => 10, 'label' => 'mine-1', 'created_at' => now(), 'updated_at' => now()],
+            ['site_id' => 10, 'label' => 'mine-2', 'created_at' => now(), 'updated_at' => now()],
+            ['site_id' => 20, 'label' => 'theirs', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        $labels = MultisiteScopedHost::scope(MultisiteRecord::query())->pluck('label')->all();
+
+        $this->assertEqualsCanonicalizing(['mine-1', 'mine-2'], $labels);
+    }
+
+    public function test_user_with_no_owned_sites_gets_zero_rows(): void
+    {
+        $this->activateFakeMultisite();
+        $loner = $this->makeUser('loner');
+        $this->actingAs($loner);
+
+        DB::table('tallcms_sites')->insert([
+            ['id' => 10, 'user_id' => 999, 'name' => 'Other'],
+        ]);
+        DB::table('multisite_records')->insert([
+            ['site_id' => 10, 'label' => 'theirs', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        $this->assertCount(0, MultisiteScopedHost::scope(MultisiteRecord::query())->get());
+    }
+
+    public function test_passes_through_when_site_id_column_exists_but_multisite_not_active(): void
+    {
+        // No activateFakeMultisite() call: multisite plugin is NOT booted.
+        // This is the regression guard for the case the reviewer flagged —
+        // a host with leftover site_id columns but multisite uninstalled
+        // must not filter normal admins to zero rows.
+        $user = $this->makeUser('alice');
+        $this->actingAs($user);
+
+        DB::table('tallcms_sites')->insert([
+            ['id' => 10, 'user_id' => 999, 'name' => 'Other'],
+        ]);
+        DB::table('multisite_records')->insert([
+            ['site_id' => 10, 'label' => 'x', 'created_at' => now(), 'updated_at' => now()],
+            ['site_id' => 20, 'label' => 'y', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        $this->assertCount(2, MultisiteScopedHost::scope(MultisiteRecord::query())->get());
+    }
+
+    public function test_scope_query_to_owned_sites_passes_through_when_site_id_absent(): void
+    {
+        $user = $this->makeUser('alice');
+        $this->actingAs($user);
+
+        DB::table('global_records')->insert([
+            ['label' => 'a', 'created_at' => now(), 'updated_at' => now()],
+            ['label' => 'b', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        // scopeQueryToOwnedSites is a no-op without site_id — single-site
+        // installs of resources like CmsPage/Menu/Comment retain their
+        // pre-multisite "all rows visible to permitted users" behavior.
+        $this->assertCount(2, GlobalScopedHost::scope(GlobalRecord::query())->get());
+    }
+
+    public function test_owned_tenants_falls_back_to_user_id_when_site_id_absent(): void
+    {
+        $user = $this->makeUser('alice');
+        $this->actingAs($user);
+
+        DB::table('single_site_records')->insert([
+            ['user_id' => $user->id, 'label' => 'mine', 'created_at' => now(), 'updated_at' => now()],
+            ['user_id' => 999, 'label' => 'theirs', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        $labels = SingleSiteTenantHost::scope(SingleSiteRecord::query())->pluck('label')->all();
+
+        $this->assertSame(['mine'], $labels);
+    }
+
+    public function test_owned_tenants_uses_site_ownership_when_site_id_present(): void
+    {
+        $this->activateFakeMultisite();
+        $owner = $this->makeUser('owner');
+        $other = $this->makeUser('other');
+        $this->actingAs($owner);
+
+        DB::table('tallcms_sites')->insert([
+            ['id' => 10, 'user_id' => $owner->id, 'name' => 'Owner Site'],
+            ['id' => 20, 'user_id' => $other->id, 'name' => 'Other Site'],
+        ]);
+        DB::table('multisite_records')->insert([
+            ['site_id' => 10, 'label' => 'mine', 'created_at' => now(), 'updated_at' => now()],
+            ['site_id' => 20, 'label' => 'theirs', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        $labels = MultisiteTenantHost::scope(MultisiteRecord::query())->pluck('label')->all();
+
+        $this->assertSame(['mine'], $labels);
+    }
+
+    public function test_owned_tenants_passes_through_when_neither_column_present(): void
+    {
+        $user = $this->makeUser('alice');
+        $this->actingAs($user);
+
+        DB::table('global_records')->insert([
+            ['label' => 'a', 'created_at' => now(), 'updated_at' => now()],
+            ['label' => 'b', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        $this->assertCount(2, GlobalTenantHost::scope(GlobalRecord::query())->get());
+    }
+
+    public function test_owned_tenants_falls_back_to_user_id_when_site_id_present_but_multisite_inactive(): void
+    {
+        // Same regression guard for the OwnedTenants helper: site_id column
+        // exists but multisite plugin isn't booted → fall back to user_id.
+        $user = $this->makeUser('alice');
+        $this->actingAs($user);
+
+        // multisite_records has site_id but no user_id, so the fallback
+        // can't find user_id and should pass the query through.
+        DB::table('multisite_records')->insert([
+            ['site_id' => 10, 'label' => 'x', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        $this->assertCount(1, MultisiteTenantHost::scope(MultisiteRecord::query())->get());
+    }
+
+    public function test_cms_page_resource_filters_to_owned_sites(): void
+    {
+        $this->activateFakeMultisite();
+        $owner = $this->makeUser('owner');
+        $other = $this->makeUser('other');
+        $this->actingAs($owner);
+
+        DB::table('tallcms_sites')->insert([
+            ['id' => 10, 'user_id' => $owner->id, 'name' => 'Owner Site'],
+            ['id' => 20, 'user_id' => $other->id, 'name' => 'Other Site'],
+        ]);
+
+        DB::table('tallcms_pages')->insert([
+            [
+                'site_id' => 10,
+                'title' => json_encode(['en' => 'Mine']),
+                'slug' => json_encode(['en' => 'mine']),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'site_id' => 20,
+                'title' => json_encode(['en' => 'Theirs']),
+                'slug' => json_encode(['en' => 'theirs']),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        $rows = CmsPageResource::getEloquentQuery()->get();
+        $this->assertCount(1, $rows);
+        $this->assertSame(10, (int) $rows->first()->site_id);
+    }
+}
+
+/**
+ * Local fixture: avoids the host TestCase's Spatie HasRoles dependency by
+ * defining its own hasRole() that the trait can probe via method_exists.
+ */
+class ScopingTestUser extends Authenticatable
+{
+    protected $table = 'users';
+
+    protected $guarded = [];
+
+    public bool $isSuperAdmin = false;
+
+    public function hasRole($role): bool
+    {
+        return $this->isSuperAdmin && $role === 'super_admin';
+    }
+}
+
+class MultisiteRecord extends Model
+{
+    protected $table = 'multisite_records';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+}
+
+class SingleSiteRecord extends Model
+{
+    protected $table = 'single_site_records';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+}
+
+class GlobalRecord extends Model
+{
+    protected $table = 'global_records';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+}
+
+class MultisiteScopedHost
+{
+    use ScopesQueryToOwnedSites;
+
+    public static function scope(Builder $q): Builder
+    {
+        return static::scopeQueryToOwnedSites($q);
+    }
+}
+
+class GlobalScopedHost
+{
+    use ScopesQueryToOwnedSites;
+
+    public static function scope(Builder $q): Builder
+    {
+        return static::scopeQueryToOwnedSites($q);
+    }
+}
+
+class MultisiteTenantHost
+{
+    use ScopesQueryToOwnedSites;
+
+    public static function scope(Builder $q): Builder
+    {
+        return static::scopeQueryToOwnedTenants($q);
+    }
+}
+
+class SingleSiteTenantHost
+{
+    use ScopesQueryToOwnedSites;
+
+    public static function scope(Builder $q): Builder
+    {
+        return static::scopeQueryToOwnedTenants($q);
+    }
+}
+
+class GlobalTenantHost
+{
+    use ScopesQueryToOwnedSites;
+
+    public static function scope(Builder $q): Builder
+    {
+        return static::scopeQueryToOwnedTenants($q);
+    }
+}


### PR DESCRIPTION
## Summary

Filament resources for site-owned content listed every tenant's records on `/cms-pages`, `/tallcms-menus`, `/cms-posts`, etc. Per-record policies still blocked edit/delete, but row titles, slugs, statuses, and counts leaked across tenants — visible to any user with the bare `ViewAny` permission.

The existing `Tallcms\Multisite\Scopes\SiteScope` is intentionally **frontend-only** (its docblock says admin should rely on RelationManagers + policies for tenant isolation), and Filament's per-record policy is not invoked when building a list query. So nothing was filtering admin list pages.

## Fix

Extend the existing `ScopesQueryToOwnedSites` trait with a second helper, `scopeQueryToOwnedTenants`, that falls back to `user_id` when `site_id` is absent. Each site-owned resource calls the helper appropriate to its semantics:

| Resource | Helper | Multisite | Standalone |
|---|---|---|---|
| `CmsPageResource` | `scopeQueryToOwnedSites` | filter by owned sites | unfiltered (prior behavior) |
| `TallcmsMenuResource` | `scopeQueryToOwnedSites` | filter by owned sites | unfiltered (prior behavior) |
| `CmsPostResource` | `scopeQueryToOwnedTenants` | filter by owned sites | filter by `user_id` (prior behavior) |
| `CmsCategoryResource` | `scopeQueryToOwnedTenants` | filter by owned sites | filter by `user_id` (prior behavior) |
| `MediaCollectionResource` | `scopeQueryToOwnedTenants` | filter by owned sites | filter by `user_id` (prior behavior) |
| `TallcmsMediaResource` | `scopeQueryToOwnedTenants` | filter by owned sites | filter by `user_id` (prior behavior) |
| `CmsCommentResource` | (already used trait) | unchanged | unchanged |
| `TallcmsContactSubmissionResource` | (already used trait) | unchanged | unchanged |

`super_admin` always bypasses; users with no owned sites see zero rows in multisite.

### Multisite-active gating

Both helpers gate site-based filtering on `tallcms_multisite_active()`, **not** the bare presence of a `site_id` column. A host with leftover columns from an uninstalled multisite would otherwise filter normal admins to zero rows against a stale `tallcms_sites` table.

## Single-site safety

Side-by-side trace for each resource confirms zero behavior change in single-site (multisite plugin not loaded):

- Pages/Menus → unfiltered before, unfiltered after.
- Posts/Categories/Media/Collections → `where user_id = auth->id()` before, same `where user_id = auth->id()` after (via the trait fallback).
- Comments/ContactSubmissions → already used the trait; unchanged.

## Tests

`tests/Unit/ScopesQueryToOwnedSitesTest.php` — 11 cases, including:

- guest / super_admin / owner-only / no-owned-sites
- standalone fallback to `user_id`
- two regression guards for the multisite-active gate (site_id column present but plugin not booted → must not filter to zero)
- one end-to-end case on `CmsPageResource::getEloquentQuery()` to catch a future regression where a resource stops delegating to the trait

A test fixture (`tests/Fixtures/FakeMultisiteSiteScope.php`) declares a stub `Tallcms\Multisite\Scopes\SiteScope` via bracketed namespace so `tallcms_multisite_active()` can be flipped on for the multisite-path tests without depending on the multisite plugin being a Composer dep of the cms package.

## Test plan

- [x] `vendor/bin/phpunit --filter ScopesQueryToOwnedSitesTest` — 11/11 pass
- [x] `vendor/bin/phpunit` (full cms suite) — 539/539 pass
- [ ] Smoke test in a single-site install: confirm Posts/Categories/Media still filter to the user's own records
- [ ] Smoke test in a multisite install: confirm a non-super-admin user can no longer see other tenants' rows on `/cms-pages`, `/tallcms-menus`, `/cms-posts`, `/tallcms-categories`, `/tallcms-media`, `/tallcms-media-collections`
- [ ] Confirm super_admin still sees everything across all six resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)