### PR TITLE
Fix Posts/Categories/Media list query regression in multisite

### DIFF
--- a/packages/tallcms/cms/src/Filament/Resources/CmsCategories/CmsCategoryResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsCategories/CmsCategoryResource.php
@@ -86,7 +86,7 @@ class CmsCategoryResource extends Resource
                 SoftDeletingScope::class,
             ]);
 
-        return static::scopeQueryToOwnedTenants($query);
+        return static::scopeQueryToOwnedByUser($query);
     }
 
     public static function getNavigationBadge(): ?string

--- a/packages/tallcms/cms/src/Filament/Resources/CmsPosts/CmsPostResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsPosts/CmsPostResource.php
@@ -93,7 +93,7 @@ class CmsPostResource extends Resource
                 SoftDeletingScope::class,
             ]);
 
-        return static::scopeQueryToOwnedTenants($query);
+        return static::scopeQueryToOwnedByUser($query);
     }
 
     public static function getNavigationBadge(): ?string

--- a/packages/tallcms/cms/src/Filament/Resources/Concerns/ScopesQueryToOwnedSites.php
+++ b/packages/tallcms/cms/src/Filament/Resources/Concerns/ScopesQueryToOwnedSites.php
@@ -63,21 +63,21 @@ trait ScopesQueryToOwnedSites
     }
 
     /**
-     * Like scopeQueryToOwnedSites, but falls back to filtering by user_id
-     * (record creator) when the table has no site_id column.
+     * Filter a query by user_id (record creator), regardless of whether
+     * multisite is active.
      *
-     * Use this for resources that exist in both multisite and standalone:
-     *   - multisite install (site_id present) → scope by owned sites
-     *   - standalone install (site_id absent, user_id present) → scope by creator
-     *   - super_admin → bypass either way
+     * Use this for resources that the multisite plugin explicitly treats as
+     * USER-OWNED rather than site-bound — Posts, Categories, Media,
+     * MediaCollections. The plugin's MultisiteServiceProvider deliberately
+     * does NOT stamp site_id on these models on creation; ownership is
+     * carried by user_id. Filtering by site_id would make a user's freshly-
+     * created records invisible to themselves in multisite installs, since
+     * site_id is NULL by design.
      *
-     * scopeQueryToOwnedSites is a no-op in standalone, which is correct for
-     * resources that have no per-user notion of ownership outside multisite
-     * (Pages, Menus, Comments, Contact Submissions). For Posts/Categories/Media,
-     * the prior single-site behavior was a per-creator filter — this helper
-     * preserves it.
+     * super_admin → bypass. No user_id column → passthrough (model isn't
+     * user-owned, nothing to scope).
      */
-    protected static function scopeQueryToOwnedTenants(Builder $query): Builder
+    protected static function scopeQueryToOwnedByUser(Builder $query): Builder
     {
         $user = auth()->user();
 
@@ -90,22 +90,13 @@ trait ScopesQueryToOwnedSites
         }
 
         $table = $query->getModel()->getTable();
-        $multisiteActive = function_exists('tallcms_multisite_active') && tallcms_multisite_active();
 
         try {
-            if ($multisiteActive && Schema::hasColumn($table, 'site_id')) {
-                $ownedSiteIds = DB::table('tallcms_sites')
-                    ->where('user_id', $user->getAuthIdentifier())
-                    ->pluck('id');
-
-                return $query->whereIn($table.'.site_id', $ownedSiteIds);
-            }
-
             if (Schema::hasColumn($table, 'user_id')) {
                 return $query->where($table.'.user_id', $user->getAuthIdentifier());
             }
         } catch (\Throwable) {
-            // Schema not yet migrated; fall through to unfiltered query.
+            // Schema not yet migrated.
         }
 
         return $query;

--- a/packages/tallcms/cms/src/Filament/Resources/MediaCollection/MediaCollectionResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/MediaCollection/MediaCollectionResource.php
@@ -140,7 +140,7 @@ class MediaCollectionResource extends Resource
 
     public static function getEloquentQuery(): \Illuminate\Database\Eloquent\Builder
     {
-        return static::scopeQueryToOwnedTenants(parent::getEloquentQuery());
+        return static::scopeQueryToOwnedByUser(parent::getEloquentQuery());
     }
 
     public static function getPages(): array

--- a/packages/tallcms/cms/src/Filament/Resources/TallcmsMedia/TallcmsMediaResource.php
+++ b/packages/tallcms/cms/src/Filament/Resources/TallcmsMedia/TallcmsMediaResource.php
@@ -68,7 +68,7 @@ class TallcmsMediaResource extends Resource
 
     public static function getEloquentQuery(): Builder
     {
-        return static::scopeQueryToOwnedTenants(parent::getEloquentQuery());
+        return static::scopeQueryToOwnedByUser(parent::getEloquentQuery());
     }
 
     public static function getPages(): array

--- a/packages/tallcms/cms/tests/Unit/ScopesQueryToOwnedSitesTest.php
+++ b/packages/tallcms/cms/tests/Unit/ScopesQueryToOwnedSitesTest.php
@@ -47,6 +47,17 @@ class ScopesQueryToOwnedSitesTest extends TestCase
             $table->timestamps();
         });
 
+        // Both site_id and user_id (mimics tallcms_posts / categories / media
+        // shape). site_id is nullable because the multisite plugin
+        // intentionally leaves it NULL for these user-owned models.
+        Schema::create('multisite_records_with_user_id', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('site_id')->nullable();
+            $table->unsignedBigInteger('user_id');
+            $table->string('label');
+            $table->timestamps();
+        });
+
         // Standalone-shape table (only user_id).
         Schema::create('single_site_records', function (Blueprint $table) {
             $table->id();
@@ -223,7 +234,7 @@ class ScopesQueryToOwnedSitesTest extends TestCase
         $this->assertCount(2, GlobalScopedHost::scope(GlobalRecord::query())->get());
     }
 
-    public function test_owned_tenants_falls_back_to_user_id_when_site_id_absent(): void
+    public function test_owned_by_user_filters_by_user_id(): void
     {
         $user = $this->makeUser('alice');
         $this->actingAs($user);
@@ -233,33 +244,39 @@ class ScopesQueryToOwnedSitesTest extends TestCase
             ['user_id' => 999, 'label' => 'theirs', 'created_at' => now(), 'updated_at' => now()],
         ]);
 
-        $labels = SingleSiteTenantHost::scope(SingleSiteRecord::query())->pluck('label')->all();
+        $labels = OwnedByUserHost::scope(SingleSiteRecord::query())->pluck('label')->all();
 
         $this->assertSame(['mine'], $labels);
     }
 
-    public function test_owned_tenants_uses_site_ownership_when_site_id_present(): void
+    public function test_owned_by_user_does_not_filter_by_site_id_in_multisite(): void
     {
+        // Regression guard for the multisite plugin's intentional design:
+        // Posts/Categories/Media/Collections are USER-OWNED, not site-bound,
+        // and site_id is deliberately left NULL on creation. A previous
+        // implementation filtered these by site_id IN (owned sites) when
+        // multisite was active, which made a user's own freshly-created
+        // records invisible to themselves (their own post had site_id=NULL).
         $this->activateFakeMultisite();
-        $owner = $this->makeUser('owner');
-        $other = $this->makeUser('other');
-        $this->actingAs($owner);
+        $user = $this->makeUser('alice');
+        $this->actingAs($user);
 
         DB::table('tallcms_sites')->insert([
-            ['id' => 10, 'user_id' => $owner->id, 'name' => 'Owner Site'],
-            ['id' => 20, 'user_id' => $other->id, 'name' => 'Other Site'],
+            ['id' => 10, 'user_id' => $user->id, 'name' => 'My Site'],
         ]);
-        DB::table('multisite_records')->insert([
-            ['site_id' => 10, 'label' => 'mine', 'created_at' => now(), 'updated_at' => now()],
-            ['site_id' => 20, 'label' => 'theirs', 'created_at' => now(), 'updated_at' => now()],
+        DB::table('multisite_records_with_user_id')->insert([
+            ['site_id' => null, 'user_id' => $user->id, 'label' => 'mine-no-site', 'created_at' => now(), 'updated_at' => now()],
+            ['site_id' => 10, 'user_id' => $user->id, 'label' => 'mine-with-site', 'created_at' => now(), 'updated_at' => now()],
+            ['site_id' => 10, 'user_id' => 999, 'label' => 'theirs', 'created_at' => now(), 'updated_at' => now()],
         ]);
 
-        $labels = MultisiteTenantHost::scope(MultisiteRecord::query())->pluck('label')->all();
+        $labels = OwnedByUserHost::scope(MultisiteRecordWithUserId::query())->pluck('label')->all();
 
-        $this->assertSame(['mine'], $labels);
+        // Both of the user's records, regardless of site_id state.
+        $this->assertEqualsCanonicalizing(['mine-no-site', 'mine-with-site'], $labels);
     }
 
-    public function test_owned_tenants_passes_through_when_neither_column_present(): void
+    public function test_owned_by_user_passes_through_when_no_user_id_column(): void
     {
         $user = $this->makeUser('alice');
         $this->actingAs($user);
@@ -269,23 +286,20 @@ class ScopesQueryToOwnedSitesTest extends TestCase
             ['label' => 'b', 'created_at' => now(), 'updated_at' => now()],
         ]);
 
-        $this->assertCount(2, GlobalTenantHost::scope(GlobalRecord::query())->get());
+        $this->assertCount(2, OwnedByUserHost::scope(GlobalRecord::query())->get());
     }
 
-    public function test_owned_tenants_falls_back_to_user_id_when_site_id_present_but_multisite_inactive(): void
+    public function test_owned_by_user_super_admin_bypasses_filter(): void
     {
-        // Same regression guard for the OwnedTenants helper: site_id column
-        // exists but multisite plugin isn't booted → fall back to user_id.
-        $user = $this->makeUser('alice');
-        $this->actingAs($user);
+        $admin = $this->makeUser('admin', superAdmin: true);
+        $this->actingAs($admin);
 
-        // multisite_records has site_id but no user_id, so the fallback
-        // can't find user_id and should pass the query through.
-        DB::table('multisite_records')->insert([
-            ['site_id' => 10, 'label' => 'x', 'created_at' => now(), 'updated_at' => now()],
+        DB::table('single_site_records')->insert([
+            ['user_id' => $admin->id, 'label' => 'mine', 'created_at' => now(), 'updated_at' => now()],
+            ['user_id' => 999, 'label' => 'theirs', 'created_at' => now(), 'updated_at' => now()],
         ]);
 
-        $this->assertCount(1, MultisiteTenantHost::scope(MultisiteRecord::query())->get());
+        $this->assertCount(2, OwnedByUserHost::scope(SingleSiteRecord::query())->get());
     }
 
     public function test_cms_page_resource_filters_to_owned_sites(): void
@@ -350,6 +364,15 @@ class MultisiteRecord extends Model
     public $timestamps = false;
 }
 
+class MultisiteRecordWithUserId extends Model
+{
+    protected $table = 'multisite_records_with_user_id';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+}
+
 class SingleSiteRecord extends Model
 {
     protected $table = 'single_site_records';
@@ -388,32 +411,12 @@ class GlobalScopedHost
     }
 }
 
-class MultisiteTenantHost
+class OwnedByUserHost
 {
     use ScopesQueryToOwnedSites;
 
     public static function scope(Builder $q): Builder
     {
-        return static::scopeQueryToOwnedTenants($q);
-    }
-}
-
-class SingleSiteTenantHost
-{
-    use ScopesQueryToOwnedSites;
-
-    public static function scope(Builder $q): Builder
-    {
-        return static::scopeQueryToOwnedTenants($q);
-    }
-}
-
-class GlobalTenantHost
-{
-    use ScopesQueryToOwnedSites;
-
-    public static function scope(Builder $q): Builder
-    {
-        return static::scopeQueryToOwnedTenants($q);
+        return static::scopeQueryToOwnedByUser($q);
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #76. The new \`scopeQueryToOwnedTenants\` helper preferred \`site_id\` over \`user_id\` when multisite was active — but the multisite plugin's \`MultisiteServiceProvider:313-315\` is explicit:

> Posts, categories, media, collections are USER-OWNED. site_id is no longer assigned for these models.

Multisite **intentionally** leaves \`site_id\` NULL on those four models. With #76 in place, a site_owner creating a new post would see it vanish from the list (NULL \`site_id\` ∉ any owned-sites set) and 404 on the redirect-to-edit.

## Repro (before this PR)

1. Log in as a non-super-admin (\`site_owner\`) on a multisite-enabled tallcms install.
2. Create a new post via Filament. The post is saved with \`user_id=<you>\`, \`site_id=NULL\`.
3. After save, Filament redirects to \`/admin/cms-posts/<id>/edit\`.
4. \`CmsPostResource::getEloquentQuery()\` applies \`whereIn site_id IN (your owned sites)\` — the new record's NULL site_id is excluded → **404**.

## Fix

Replace \`scopeQueryToOwnedTenants\` with \`scopeQueryToOwnedByUser\`, which always filters by \`user_id\` regardless of multisite mode (super_admin still bypasses, no \`user_id\` column still passes through). This matches the plugin's ownership model and is identical to the prior inline behavior in those four resources before #76 centralized them.

| Resource | Helper |
|---|---|
| \`CmsPageResource\` | \`scopeQueryToOwnedSites\` (unchanged — site-bound) |
| \`TallcmsMenuResource\` | \`scopeQueryToOwnedSites\` (unchanged — site-bound) |
| \`CmsCommentResource\` | \`scopeQueryToOwnedSites\` (unchanged) |
| \`TallcmsContactSubmissionResource\` | \`scopeQueryToOwnedSites\` (unchanged) |
| \`CmsPostResource\` | **\`scopeQueryToOwnedByUser\`** (was: \`scopeQueryToOwnedTenants\`) |
| \`CmsCategoryResource\` | **\`scopeQueryToOwnedByUser\`** (was: \`scopeQueryToOwnedTenants\`) |
| \`MediaCollectionResource\` | **\`scopeQueryToOwnedByUser\`** (was: \`scopeQueryToOwnedTenants\`) |
| \`TallcmsMediaResource\` | **\`scopeQueryToOwnedByUser\`** (was: \`scopeQueryToOwnedTenants\`) |

## Tests

Replaced the four \`scopeQueryToOwnedTenants\` cases with four \`scopeQueryToOwnedByUser\` cases, including \`test_owned_by_user_does_not_filter_by_site_id_in_multisite\` — an explicit regression guard that activates fake multisite and asserts the user's own NULL-\`site_id\` record stays visible.

- [x] \`vendor/bin/phpunit --filter ScopesQueryToOwnedSitesTest\` — 11/11 pass
- [x] \`vendor/bin/phpunit\` (full cms suite) — 539/539 pass
- [x] Live-verified on a multisite-active tallcms install: previously-404'ing post is now visible to its owner, and a non-super-admin no longer sees other tenants' posts/categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)