### PR TITLE
Add DashboardSitePicker so widgets honour an explicit site scope

### DIFF
--- a/packages/tallcms/cms/resources/views/filament/widgets/dashboard-site-picker.blade.php
+++ b/packages/tallcms/cms/resources/views/filament/widgets/dashboard-site-picker.blade.php
@@ -1,0 +1,24 @@
+<x-filament-widgets::widget>
+    <x-filament::section>
+        <x-slot name="heading">
+            Dashboard scope
+        </x-slot>
+
+        <x-slot name="description">
+            Pick which site's data to show in the widgets below. This is separate from the site switcher in the navbar — that one takes you into a site's edit page.
+        </x-slot>
+
+        <select
+            wire:model.live="selected"
+            class="w-full rounded-lg border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-base-content"
+        >
+            @if ($this->isSuperAdmin())
+                <option value="__all_sites__">All Sites</option>
+            @endif
+
+            @foreach ($this->sitesForUser as $site)
+                <option value="{{ $site->id }}">{{ $site->name }}</option>
+            @endforeach
+        </select>
+    </x-filament::section>
+</x-filament-widgets::widget>

--- a/packages/tallcms/cms/src/Filament/Widgets/Concerns/HasMultisiteWidgetContext.php
+++ b/packages/tallcms/cms/src/Filament/Widgets/Concerns/HasMultisiteWidgetContext.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TallCms\Cms\Filament\Widgets\Concerns;
+
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Multisite scoping helpers for dashboard widgets.
+ *
+ * Reads the dashboard's "current site" from session('multisite_admin_site_id'),
+ * with role-based fallback when the session isn't set yet.
+ *
+ * Session value semantics:
+ *   - '__all_sites__'    → null (caller's signal to skip the site filter)
+ *   - numeric            → that specific site_id
+ *   - missing            → role-based fallback:
+ *                            super_admin → default site
+ *                            others      → first owned site
+ *
+ * Guards QueryException so installs without the multisite plugin (no
+ * tallcms_sites table) degrade gracefully to null instead of erroring out.
+ */
+trait HasMultisiteWidgetContext
+{
+    protected function getMultisiteSiteId(): ?int
+    {
+        $sessionValue = session('multisite_admin_site_id');
+
+        if ($sessionValue === '__all_sites__') {
+            return null;
+        }
+
+        if ($sessionValue && is_numeric($sessionValue)) {
+            return (int) $sessionValue;
+        }
+
+        try {
+            if (auth()->check() && ! auth()->user()->hasRole('super_admin')) {
+                $firstOwned = DB::table('tallcms_sites')
+                    ->where('user_id', auth()->id())
+                    ->where('is_active', true)
+                    ->orderBy('created_at')
+                    ->value('id');
+
+                return $firstOwned ? (int) $firstOwned : null;
+            }
+
+            $default = DB::table('tallcms_sites')->where('is_default', true)->value('id');
+
+            return $default ? (int) $default : null;
+        } catch (QueryException) {
+            return null;
+        }
+    }
+
+    protected function getMultisiteName(?int $siteId): ?string
+    {
+        $sessionValue = session('multisite_admin_site_id');
+
+        if ($sessionValue === '__all_sites__') {
+            return 'All Sites';
+        }
+
+        if (! $siteId) {
+            return null;
+        }
+
+        try {
+            $site = DB::table('tallcms_sites')->where('id', $siteId)->first();
+
+            return $site?->name;
+        } catch (QueryException) {
+            return null;
+        }
+    }
+
+    protected function isAllSitesSelected(): bool
+    {
+        return session('multisite_admin_site_id') === '__all_sites__';
+    }
+}

--- a/packages/tallcms/cms/src/Filament/Widgets/ContentHealthWidget.php
+++ b/packages/tallcms/cms/src/Filament/Widgets/ContentHealthWidget.php
@@ -5,13 +5,23 @@ namespace TallCms\Cms\Filament\Widgets;
 use Carbon\Carbon;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
-use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Livewire\Attributes\On;
+use TallCms\Cms\Filament\Widgets\Concerns\HasMultisiteWidgetContext;
 
 class ContentHealthWidget extends BaseWidget
 {
+    use HasMultisiteWidgetContext;
+
     protected static ?int $sort = 1;
+
+    #[On('dashboard.site-changed')]
+    public function onSiteChanged(): void
+    {
+        // Empty body — Livewire re-renders the widget on event receipt,
+        // which re-runs getStats() against the new session value.
+    }
 
     protected function getStats(): array
     {
@@ -85,55 +95,4 @@ class ContentHealthWidget extends BaseWidget
         return $siteName ? "Content Health — {$siteName}" : 'Content Health';
     }
 
-    protected function getMultisiteSiteId(): ?int
-    {
-        $sessionValue = session('multisite_admin_site_id');
-
-        if ($sessionValue === '__all_sites__') {
-            return null;
-        }
-
-        if ($sessionValue && is_numeric($sessionValue)) {
-            return (int) $sessionValue;
-        }
-
-        try {
-            if (auth()->check() && ! auth()->user()->hasRole('super_admin')) {
-                $firstOwned = DB::table('tallcms_sites')
-                    ->where('user_id', auth()->id())
-                    ->where('is_active', true)
-                    ->orderBy('created_at')
-                    ->value('id');
-
-                return $firstOwned ? (int) $firstOwned : null;
-            }
-
-            $default = DB::table('tallcms_sites')->where('is_default', true)->value('id');
-
-            return $default ? (int) $default : null;
-        } catch (QueryException) {
-            return null;
-        }
-    }
-
-    protected function getMultisiteName(?int $siteId): ?string
-    {
-        $sessionValue = session('multisite_admin_site_id');
-
-        if ($sessionValue === '__all_sites__') {
-            return 'All Sites';
-        }
-
-        if (! $siteId) {
-            return null;
-        }
-
-        try {
-            $site = DB::table('tallcms_sites')->where('id', $siteId)->first();
-
-            return $site?->name;
-        } catch (QueryException) {
-            return null;
-        }
-    }
 }

--- a/packages/tallcms/cms/src/Filament/Widgets/DashboardSitePicker.php
+++ b/packages/tallcms/cms/src/Filament/Widgets/DashboardSitePicker.php
@@ -36,21 +36,27 @@ class DashboardSitePicker extends Widget
     public function mount(): void
     {
         $current = session('multisite_admin_site_id');
+        $authorized = $this->resolveAuthorizedSiteValue($current);
 
-        if ($current === '__all_sites__' || (is_string($current) && is_numeric($current))) {
-            $this->selected = (string) $current;
+        if ($authorized !== null) {
+            $this->selected = is_int($authorized) ? (string) $authorized : $authorized;
+
+            // Normalize stale/typed session value (e.g. coerce string id → int)
+            // so downstream consumers see a consistent shape.
+            if ($current !== $authorized) {
+                session(['multisite_admin_site_id' => $authorized]);
+            }
 
             return;
         }
 
-        if (is_int($current)) {
-            $this->selected = (string) $current;
+        // No valid session value yet (or a stale value the current user can't
+        // access) — clear it first so the trait's role-based fallback is reached.
+        // (The trait short-circuits on a session value of '__all_sites__' or any
+        // numeric id without validating ownership; for unauthorized values we
+        // need a fresh fallback resolution.)
+        session()->forget('multisite_admin_site_id');
 
-            return;
-        }
-
-        // First load: seed session using the same role-based fallback the trait
-        // resolves so first dashboard load matches pre-picker behaviour.
         $fallback = $this->getMultisiteSiteId();
         if ($fallback !== null) {
             $this->selected = (string) $fallback;
@@ -60,11 +66,65 @@ class DashboardSitePicker extends Widget
 
     public function updatedSelected(string|int $value): void
     {
-        $stored = $value === '__all_sites__' ? '__all_sites__' : (int) $value;
+        $authorized = $this->resolveAuthorizedSiteValue($value);
 
-        session(['multisite_admin_site_id' => $stored]);
+        if ($authorized === null) {
+            // Tampered or unauthorized value (e.g. non-super-admin trying to
+            // set __all_sites__, or any user trying to pick a site they don't
+            // own). Revert the picker UI to the current session value without
+            // dispatching, so other widgets don't refresh against bad scope.
+            $this->selected = is_string(session('multisite_admin_site_id'))
+                || is_int(session('multisite_admin_site_id'))
+                    ? (string) session('multisite_admin_site_id')
+                    : null;
 
-        $this->dispatch('dashboard.site-changed', siteId: $stored);
+            return;
+        }
+
+        session(['multisite_admin_site_id' => $authorized]);
+
+        $this->dispatch('dashboard.site-changed', siteId: $authorized);
+    }
+
+    /**
+     * Validate a candidate scope value against the current user's access.
+     * Returns the canonical value to write to session, or null if the value
+     * is not allowed for this user.
+     *
+     * - '__all_sites__' is only valid for super_admins.
+     * - A numeric site_id is only valid if the site exists, is active, and
+     *   either the user is super_admin or owns the site.
+     * - Anything else (null, garbage strings, expired ids) returns null.
+     */
+    protected function resolveAuthorizedSiteValue(mixed $value): null|int|string
+    {
+        if (! auth()->check()) {
+            return null;
+        }
+
+        if ($value === '__all_sites__') {
+            return $this->isSuperAdmin() ? '__all_sites__' : null;
+        }
+
+        if (! is_numeric($value)) {
+            return null;
+        }
+
+        $siteId = (int) $value;
+
+        try {
+            $query = DB::table('tallcms_sites')
+                ->where('id', $siteId)
+                ->where('is_active', true);
+
+            if (! $this->isSuperAdmin()) {
+                $query->where('user_id', auth()->id());
+            }
+
+            return $query->exists() ? $siteId : null;
+        } catch (\Throwable) {
+            return null;
+        }
     }
 
     /**

--- a/packages/tallcms/cms/src/Filament/Widgets/DashboardSitePicker.php
+++ b/packages/tallcms/cms/src/Filament/Widgets/DashboardSitePicker.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TallCms\Cms\Filament\Widgets;
+
+use Filament\Widgets\Widget;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use TallCms\Cms\Filament\Widgets\Concerns\HasMultisiteWidgetContext;
+
+/**
+ * Dashboard scope picker.
+ *
+ * Surfaces "which site's data should the dashboard widgets show?"
+ * as an explicit affordance, separate from SiteSwitcher (which navigates
+ * into a site's edit page and intentionally does NOT mutate session).
+ *
+ * Writes session('multisite_admin_site_id') and broadcasts the
+ * 'dashboard.site-changed' Livewire event so other widgets refresh
+ * without a full page reload.
+ */
+class DashboardSitePicker extends Widget
+{
+    use HasMultisiteWidgetContext;
+
+    protected string $view = 'tallcms::filament.widgets.dashboard-site-picker';
+
+    protected static ?int $sort = -100;
+
+    protected int|string|array $columnSpan = 'full';
+
+    public ?string $selected = null;
+
+    public function mount(): void
+    {
+        $current = session('multisite_admin_site_id');
+
+        if ($current === '__all_sites__' || (is_string($current) && is_numeric($current))) {
+            $this->selected = (string) $current;
+
+            return;
+        }
+
+        if (is_int($current)) {
+            $this->selected = (string) $current;
+
+            return;
+        }
+
+        // First load: seed session using the same role-based fallback the trait
+        // resolves so first dashboard load matches pre-picker behaviour.
+        $fallback = $this->getMultisiteSiteId();
+        if ($fallback !== null) {
+            $this->selected = (string) $fallback;
+            session(['multisite_admin_site_id' => $fallback]);
+        }
+    }
+
+    public function updatedSelected(string|int $value): void
+    {
+        $stored = $value === '__all_sites__' ? '__all_sites__' : (int) $value;
+
+        session(['multisite_admin_site_id' => $stored]);
+
+        $this->dispatch('dashboard.site-changed', siteId: $stored);
+    }
+
+    /**
+     * @return Collection<int, object{id:int,name:string}>
+     */
+    public function getSitesForUserProperty(): Collection
+    {
+        try {
+            $query = DB::table('tallcms_sites')
+                ->where('is_active', true)
+                ->orderBy('name');
+
+            if (auth()->check() && ! auth()->user()->hasRole('super_admin')) {
+                $query->where('user_id', auth()->id());
+            }
+
+            return $query->get(['id', 'name']);
+        } catch (\Throwable) {
+            return collect();
+        }
+    }
+
+    public function isSuperAdmin(): bool
+    {
+        return auth()->check() && auth()->user()->hasRole('super_admin');
+    }
+
+    public static function canView(): bool
+    {
+        try {
+            if (! Schema::hasTable('tallcms_sites')) {
+                return false;
+            }
+
+            if (! auth()->check()) {
+                return false;
+            }
+
+            // Super-admins see the picker even with no owned sites
+            // (they can pick any site or "All Sites").
+            if (auth()->user()->hasRole('super_admin')) {
+                return true;
+            }
+
+            // Regular users only see the picker if they own at least one site.
+            $ownedCount = DB::table('tallcms_sites')
+                ->where('user_id', auth()->id())
+                ->where('is_active', true)
+                ->count();
+
+            return $ownedCount > 0;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+}

--- a/packages/tallcms/cms/src/Filament/Widgets/MenuOverviewWidget.php
+++ b/packages/tallcms/cms/src/Filament/Widgets/MenuOverviewWidget.php
@@ -4,12 +4,22 @@ namespace TallCms\Cms\Filament\Widgets;
 
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
-use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Livewire\Attributes\On;
+use TallCms\Cms\Filament\Widgets\Concerns\HasMultisiteWidgetContext;
 
 class MenuOverviewWidget extends BaseWidget
 {
+    use HasMultisiteWidgetContext;
+
+    #[On('dashboard.site-changed')]
+    public function onSiteChanged(): void
+    {
+        // Empty body — Livewire re-renders the widget on event receipt,
+        // which re-runs getStats() against the new session value.
+    }
+
     protected function getStats(): array
     {
         $siteId = $this->getMultisiteSiteId();
@@ -84,67 +94,4 @@ class MenuOverviewWidget extends BaseWidget
         return $siteName ? "Content Overview — {$siteName}" : 'Content Overview';
     }
 
-    /**
-     * Get the current admin-selected site ID from session.
-     * Returns null when multisite is not active or "All Sites" is selected.
-     */
-    protected function getMultisiteSiteId(): ?int
-    {
-        $sessionValue = session('multisite_admin_site_id');
-
-        // Explicit "All Sites" selection
-        if ($sessionValue === '__all_sites__') {
-            return null;
-        }
-
-        // Specific site selected
-        if ($sessionValue && is_numeric($sessionValue)) {
-            return (int) $sessionValue;
-        }
-
-        // No session yet (first login) — fall back based on role
-        try {
-            if (auth()->check() && ! auth()->user()->hasRole('super_admin')) {
-                // Non-super-admin: first owned site (deterministic: oldest)
-                $firstOwned = DB::table('tallcms_sites')
-                    ->where('user_id', auth()->id())
-                    ->where('is_active', true)
-                    ->orderBy('created_at')
-                    ->value('id');
-
-                return $firstOwned ? (int) $firstOwned : null;
-            }
-
-            // Super-admin: global default site
-            $default = DB::table('tallcms_sites')->where('is_default', true)->value('id');
-
-            return $default ? (int) $default : null;
-        } catch (QueryException) {
-            return null;
-        }
-    }
-
-    /**
-     * Get the display name for the current multisite context.
-     */
-    protected function getMultisiteName(?int $siteId): ?string
-    {
-        $sessionValue = session('multisite_admin_site_id');
-
-        if ($sessionValue === '__all_sites__') {
-            return 'All Sites';
-        }
-
-        if (! $siteId) {
-            return null;
-        }
-
-        try {
-            $site = DB::table('tallcms_sites')->where('id', $siteId)->first();
-
-            return $site?->name;
-        } catch (QueryException) {
-            return null;
-        }
-    }
 }

--- a/packages/tallcms/cms/src/TallCmsPlugin.php
+++ b/packages/tallcms/cms/src/TallCmsPlugin.php
@@ -32,6 +32,7 @@ use TallCms\Cms\Filament\Resources\TallcmsMedia\TallcmsMediaResource;
 use TallCms\Cms\Filament\Resources\TallcmsMenus\TallcmsMenuResource;
 use TallCms\Cms\Filament\Resources\Users\UserResource;
 use TallCms\Cms\Filament\Widgets\ContentHealthWidget;
+use TallCms\Cms\Filament\Widgets\DashboardSitePicker;
 use TallCms\Cms\Filament\Widgets\MenuOverviewWidget;
 use TallCms\Cms\Filament\Widgets\PluginUpdatesWidget;
 use TallCms\Cms\Services\LocaleRegistry;
@@ -307,7 +308,11 @@ class TallCmsPlugin implements Plugin
      */
     public function getWidgets(): array
     {
-        $widgets = [];
+        // Picker is registered unconditionally; its canView() guards on
+        // multisite plugin presence + user-accessible sites with try/catch
+        // so install / migration / DB-unavailable contexts can't blow up
+        // panel boot.
+        $widgets = [DashboardSitePicker::class];
 
         if ($this->hasPosts) {
             $widgets[] = ContentHealthWidget::class;

--- a/packages/tallcms/cms/tests/Unit/HasMultisiteWidgetContextTest.php
+++ b/packages/tallcms/cms/tests/Unit/HasMultisiteWidgetContextTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TallCms\Cms\Tests\Unit;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Permission\Models\Role;
+use TallCms\Cms\Filament\Widgets\Concerns\HasMultisiteWidgetContext;
+use TallCms\Cms\Tests\Fixtures\User;
+use TallCms\Cms\Tests\TestCase;
+
+/**
+ * Anonymous-class-style consumer of the trait, exposing the protected
+ * methods publicly for assertion. Keeps the test self-contained.
+ */
+class WidgetContextProbe
+{
+    use HasMultisiteWidgetContext {
+        getMultisiteSiteId as public;
+        getMultisiteName as public;
+        isAllSitesSelected as public;
+    }
+}
+
+class HasMultisiteWidgetContextTest extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return array_merge(parent::getPackageProviders($app), [
+            \Spatie\Permission\PermissionServiceProvider::class,
+        ]);
+    }
+
+    protected function defineDatabaseMigrations(): void
+    {
+        parent::defineDatabaseMigrations();
+
+        Schema::create('tallcms_sites', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->boolean('is_default')->default(false);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+
+        // Spatie Permission tables
+        $config = $this->app['config'];
+        $config->set('permission.table_names', [
+            'roles' => 'roles',
+            'permissions' => 'permissions',
+            'model_has_permissions' => 'model_has_permissions',
+            'model_has_roles' => 'model_has_roles',
+            'role_has_permissions' => 'role_has_permissions',
+        ]);
+        $config->set('permission.column_names', [
+            'role_pivot_key' => null,
+            'permission_pivot_key' => null,
+            'model_morph_key' => 'model_id',
+            'team_foreign_key' => 'team_id',
+        ]);
+
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+        });
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+        });
+        Schema::create('model_has_roles', function (Blueprint $table) {
+            $table->unsignedBigInteger('role_id');
+            $table->string('model_type');
+            $table->unsignedBigInteger('model_id');
+        });
+        Schema::create('model_has_permissions', function (Blueprint $table) {
+            $table->unsignedBigInteger('permission_id');
+            $table->string('model_type');
+            $table->unsignedBigInteger('model_id');
+        });
+        Schema::create('role_has_permissions', function (Blueprint $table) {
+            $table->unsignedBigInteger('permission_id');
+            $table->unsignedBigInteger('role_id');
+        });
+    }
+
+    public function test_specific_site_id_in_session_returns_that_id(): void
+    {
+        session(['multisite_admin_site_id' => 42]);
+
+        $this->assertSame(42, (new WidgetContextProbe)->getMultisiteSiteId());
+    }
+
+    public function test_all_sites_sentinel_returns_null(): void
+    {
+        session(['multisite_admin_site_id' => '__all_sites__']);
+
+        $this->assertNull((new WidgetContextProbe)->getMultisiteSiteId());
+    }
+
+    public function test_super_admin_falls_back_to_default_site(): void
+    {
+        session()->forget('multisite_admin_site_id');
+        Role::create(['name' => 'super_admin', 'guard_name' => 'web']);
+        $user = User::create(['name' => 'Boss', 'email' => 'boss@example.com', 'password' => 'x']);
+        $user->assignRole('super_admin');
+        $this->actingAs($user);
+
+        \DB::table('tallcms_sites')->insert([
+            ['id' => 7, 'name' => 'Main', 'is_default' => true, 'is_active' => true, 'user_id' => $user->id, 'created_at' => now(), 'updated_at' => now()],
+            ['id' => 8, 'name' => 'Other', 'is_default' => false, 'is_active' => true, 'user_id' => $user->id, 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        $this->assertSame(7, (new WidgetContextProbe)->getMultisiteSiteId());
+    }
+
+    public function test_non_super_admin_falls_back_to_first_owned_site(): void
+    {
+        session()->forget('multisite_admin_site_id');
+        $user = User::create(['name' => 'Editor', 'email' => 'editor@example.com', 'password' => 'x']);
+        $this->actingAs($user);
+
+        \DB::table('tallcms_sites')->insert([
+            ['id' => 11, 'name' => 'A', 'is_default' => false, 'is_active' => true, 'user_id' => $user->id, 'created_at' => now()->subDay(), 'updated_at' => now()],
+            ['id' => 12, 'name' => 'B', 'is_default' => false, 'is_active' => true, 'user_id' => $user->id, 'created_at' => now(), 'updated_at' => now()],
+            ['id' => 13, 'name' => 'C-others', 'is_default' => false, 'is_active' => true, 'user_id' => 99999, 'created_at' => now()->subWeek(), 'updated_at' => now()],
+        ]);
+
+        // Should pick site 11 (oldest owned by this user), NOT 13 (older but not owned).
+        $this->assertSame(11, (new WidgetContextProbe)->getMultisiteSiteId());
+    }
+
+    public function test_query_exception_falls_through_to_null(): void
+    {
+        Schema::drop('tallcms_sites');
+        session()->forget('multisite_admin_site_id');
+
+        $this->assertNull((new WidgetContextProbe)->getMultisiteSiteId());
+    }
+
+    public function test_multisite_name_returns_all_sites_sentinel(): void
+    {
+        session(['multisite_admin_site_id' => '__all_sites__']);
+
+        $this->assertSame('All Sites', (new WidgetContextProbe)->getMultisiteName(null));
+    }
+
+    public function test_multisite_name_returns_site_row_name(): void
+    {
+        \DB::table('tallcms_sites')->insert([
+            'id' => 99, 'name' => 'My Site', 'is_default' => false, 'is_active' => true, 'user_id' => 1, 'created_at' => now(), 'updated_at' => now(),
+        ]);
+
+        $this->assertSame('My Site', (new WidgetContextProbe)->getMultisiteName(99));
+    }
+
+    public function test_multisite_name_returns_null_for_missing_id(): void
+    {
+        $this->assertNull((new WidgetContextProbe)->getMultisiteName(null));
+    }
+
+    public function test_is_all_sites_selected_true_on_sentinel(): void
+    {
+        session(['multisite_admin_site_id' => '__all_sites__']);
+
+        $this->assertTrue((new WidgetContextProbe)->isAllSitesSelected());
+    }
+
+    public function test_is_all_sites_selected_false_on_specific_id(): void
+    {
+        session(['multisite_admin_site_id' => 42]);
+
+        $this->assertFalse((new WidgetContextProbe)->isAllSitesSelected());
+    }
+
+    public function test_is_all_sites_selected_false_when_session_unset(): void
+    {
+        session()->forget('multisite_admin_site_id');
+
+        $this->assertFalse((new WidgetContextProbe)->isAllSitesSelected());
+    }
+}

--- a/tests/Feature/Widgets/AnalyticsOverviewWidgetTest.php
+++ b/tests/Feature/Widgets/AnalyticsOverviewWidgetTest.php
@@ -23,6 +23,13 @@ class AnalyticsOverviewWidgetTest extends TestCase
             $this->markTestSkipped('Pro plugin not installed.');
         }
 
+        // Skip when Pro is installed at a version that predates the multisite-
+        // aware refactor (v1.10.0+). Lets developers running older Pro builds
+        // not have these tests fail until they upgrade.
+        if (! property_exists(\Tallcms\Pro\Filament\Widgets\AnalyticsOverviewWidget::class, 'isAllSites')) {
+            $this->markTestSkipped('Pro plugin too old (need 1.10.0+ for multisite-aware widgets).');
+        }
+
         if (! class_exists(Site::class)) {
             $this->markTestSkipped('Multisite plugin not installed.');
         }

--- a/tests/Feature/Widgets/AnalyticsOverviewWidgetTest.php
+++ b/tests/Feature/Widgets/AnalyticsOverviewWidgetTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Widgets;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+use Tallcms\Multisite\Models\Site;
+use Tests\TestCase;
+
+class AnalyticsOverviewWidgetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! class_exists(\Tallcms\Pro\Filament\Widgets\AnalyticsOverviewWidget::class)) {
+            $this->markTestSkipped('Pro plugin not installed.');
+        }
+
+        if (! class_exists(Site::class)) {
+            $this->markTestSkipped('Multisite plugin not installed.');
+        }
+
+        Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web']);
+    }
+
+    private function makeSuperAdmin(): User
+    {
+        $user = User::create([
+            'name' => 'Boss',
+            'email' => 'boss-'.uniqid().'@example.com',
+            'password' => bcrypt('x'),
+        ]);
+        $user->assignRole('super_admin');
+        $this->actingAs($user);
+
+        return $user;
+    }
+
+    private function makeSite(array $attrs = []): Site
+    {
+        return Site::create(array_merge([
+            'name' => 'Test Site',
+            'domain' => uniqid('test-').'.example.com',
+            'uuid' => \Illuminate\Support\Str::uuid()->toString(),
+            'is_default' => false,
+            'is_active' => true,
+            'domain_verified' => true,
+            'domain_status' => 'verified',
+        ], $attrs));
+    }
+
+    public function test_all_sites_renders_empty_state(): void
+    {
+        $this->makeSite(['is_default' => true]);
+        $this->makeSuperAdmin();
+        session(['multisite_admin_site_id' => '__all_sites__']);
+
+        Livewire::test(\Tallcms\Pro\Filament\Widgets\AnalyticsOverviewWidget::class)
+            ->assertSet('isAllSites', true)
+            ->assertSet('metrics', [])
+            ->assertSet('topPages', [])
+            ->assertSet('trafficSources', [])
+            ->assertSet('visitorTrend', [])
+            ->assertSee('Analytics is per-site');
+    }
+
+    public function test_specific_site_does_not_emit_empty_state(): void
+    {
+        $site = $this->makeSite(['name' => 'Mine', 'is_default' => true]);
+        $this->makeSuperAdmin();
+        session(['multisite_admin_site_id' => $site->id]);
+
+        $component = Livewire::test(\Tallcms\Pro\Filament\Widgets\AnalyticsOverviewWidget::class);
+
+        $component->assertSet('isAllSites', false);
+        $component->assertSet('siteName', 'Mine');
+        $component->assertDontSee('Analytics is per-site. Pick a specific site');
+    }
+
+    public function test_set_period_short_circuits_on_all_sites(): void
+    {
+        $this->makeSite(['is_default' => true]);
+        $this->makeSuperAdmin();
+        session(['multisite_admin_site_id' => '__all_sites__']);
+
+        Livewire::test(\Tallcms\Pro\Filament\Widgets\AnalyticsOverviewWidget::class)
+            ->call('setPeriod', '30d')
+            ->assertSet('period', '30d')
+            ->assertSet('metrics', []);
+    }
+
+    public function test_refresh_data_short_circuits_on_all_sites(): void
+    {
+        $this->makeSite(['is_default' => true]);
+        $this->makeSuperAdmin();
+        session(['multisite_admin_site_id' => '__all_sites__']);
+
+        Livewire::test(\Tallcms\Pro\Filament\Widgets\AnalyticsOverviewWidget::class)
+            ->call('refreshData')
+            ->assertSet('metrics', []);
+    }
+
+    public function test_site_changed_event_clears_data_when_switching_to_all_sites(): void
+    {
+        $site = $this->makeSite(['is_default' => true]);
+        $this->makeSuperAdmin();
+        session(['multisite_admin_site_id' => $site->id]);
+
+        $component = Livewire::test(\Tallcms\Pro\Filament\Widgets\AnalyticsOverviewWidget::class)
+            ->set('metrics', ['some' => 'stale-data'])
+            ->set('topPages', [['url' => 'old']]);
+
+        // Simulate the picker dispatching the event
+        session(['multisite_admin_site_id' => '__all_sites__']);
+        $component->call('onSiteChanged');
+
+        $component->assertSet('isAllSites', true);
+        $component->assertSet('metrics', []);
+        $component->assertSet('topPages', []);
+    }
+}

--- a/tests/Feature/Widgets/DashboardSitePickerTest.php
+++ b/tests/Feature/Widgets/DashboardSitePickerTest.php
@@ -133,4 +133,120 @@ class DashboardSitePickerTest extends TestCase
 
         $this->assertTrue(DashboardSitePicker::canView());
     }
+
+    // -------------------------------------------------------------------------
+    // Authorization — server-side validation of Livewire-supplied selection
+    // -------------------------------------------------------------------------
+
+    public function test_regular_user_cannot_select_another_users_site(): void
+    {
+        // Insert a foreign-owned site directly via DB (bypassing the model's
+        // quota guard, which isn't what's under test here).
+        $owner = $this->makeRegularUser();
+        $foreignId = DB::table('tallcms_sites')->insertGetId([
+            'name' => 'Owner',
+            'domain' => uniqid('owner-').'.example.com',
+            'uuid' => \Illuminate\Support\Str::uuid()->toString(),
+            'user_id' => $owner->id,
+            'is_default' => false,
+            'is_active' => true,
+            'domain_verified' => true,
+            'domain_status' => 'verified',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $tamperer = $this->makeRegularUser();
+        $ownSite = $this->makeSite(['name' => 'Mine', 'user_id' => $tamperer->id]);
+        $this->actingAs($tamperer);
+
+        Livewire::test(DashboardSitePicker::class)
+            ->set('selected', (string) $foreignId)
+            ->assertNotDispatched('dashboard.site-changed');
+
+        $this->assertNotSame($foreignId, session('multisite_admin_site_id'));
+    }
+
+    public function test_regular_user_cannot_select_all_sites(): void
+    {
+        $user = $this->makeRegularUser();
+        $site = $this->makeSite(['user_id' => $user->id]);
+        $this->actingAs($user);
+
+        Livewire::test(DashboardSitePicker::class)
+            ->set('selected', '__all_sites__')
+            ->assertNotDispatched('dashboard.site-changed');
+
+        $this->assertNotSame('__all_sites__', session('multisite_admin_site_id'));
+    }
+
+    public function test_regular_user_cannot_select_inactive_site(): void
+    {
+        $user = $this->makeRegularUser();
+        $active = $this->makeSite(['name' => 'Active', 'user_id' => $user->id, 'is_active' => true]);
+        // Second site for same user — bypass quota guard via raw insert.
+        $inactiveId = DB::table('tallcms_sites')->insertGetId([
+            'name' => 'Inactive',
+            'domain' => uniqid('inactive-').'.example.com',
+            'uuid' => \Illuminate\Support\Str::uuid()->toString(),
+            'user_id' => $user->id,
+            'is_default' => false,
+            'is_active' => false,
+            'domain_verified' => true,
+            'domain_status' => 'verified',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        $this->actingAs($user);
+
+        Livewire::test(DashboardSitePicker::class)
+            ->set('selected', (string) $inactiveId)
+            ->assertNotDispatched('dashboard.site-changed');
+
+        $this->assertNotSame($inactiveId, session('multisite_admin_site_id'));
+    }
+
+    public function test_mount_normalizes_stale_unauthorized_session_value(): void
+    {
+        $owner = $this->makeRegularUser();
+        $foreignId = DB::table('tallcms_sites')->insertGetId([
+            'name' => 'Owner',
+            'domain' => uniqid('owner-').'.example.com',
+            'uuid' => \Illuminate\Support\Str::uuid()->toString(),
+            'user_id' => $owner->id,
+            'is_default' => false,
+            'is_active' => true,
+            'domain_verified' => true,
+            'domain_status' => 'verified',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $user = $this->makeRegularUser();
+        $ownSite = $this->makeSite(['name' => 'Mine', 'user_id' => $user->id]);
+        $this->actingAs($user);
+
+        // Stale session (perhaps left over from a previous login) points at
+        // a site this user can't access. Picker mount should ignore it and
+        // fall back to the user's own site.
+        session(['multisite_admin_site_id' => $foreignId]);
+
+        Livewire::test(DashboardSitePicker::class)
+            ->assertSet('selected', (string) $ownSite->id);
+
+        $this->assertSame($ownSite->id, session('multisite_admin_site_id'));
+    }
+
+    public function test_mount_rejects_stale_all_sites_for_non_super_admin(): void
+    {
+        $user = $this->makeRegularUser();
+        $site = $this->makeSite(['name' => 'Mine', 'user_id' => $user->id]);
+        $this->actingAs($user);
+        session(['multisite_admin_site_id' => '__all_sites__']);
+
+        Livewire::test(DashboardSitePicker::class)
+            ->assertSet('selected', (string) $site->id);
+
+        $this->assertSame($site->id, session('multisite_admin_site_id'));
+    }
 }

--- a/tests/Feature/Widgets/DashboardSitePickerTest.php
+++ b/tests/Feature/Widgets/DashboardSitePickerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Widgets;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+use Tallcms\Multisite\Models\Site;
+use TallCms\Cms\Filament\Widgets\DashboardSitePicker;
+use Tests\TestCase;
+
+/**
+ * Lives in the standalone test suite (not the cms package) because the
+ * picker view uses Filament's <x-filament-widgets::widget> + <x-filament::section>
+ * components that only resolve when the full panel boots. Same reason the
+ * FeaturesBlock render tests landed here in PR #72.
+ */
+class DashboardSitePickerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! class_exists(Site::class)) {
+            $this->markTestSkipped('Multisite plugin not installed.');
+        }
+
+        Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web']);
+    }
+
+    private function makeSuperAdmin(): User
+    {
+        $user = User::create([
+            'name' => 'Boss',
+            'email' => 'boss-'.uniqid().'@example.com',
+            'password' => bcrypt('x'),
+        ]);
+        $user->assignRole('super_admin');
+
+        return $user;
+    }
+
+    private function makeRegularUser(): User
+    {
+        return User::create([
+            'name' => 'User',
+            'email' => 'user-'.uniqid().'@example.com',
+            'password' => bcrypt('x'),
+        ]);
+    }
+
+    private function makeSite(array $attrs = []): Site
+    {
+        return Site::create(array_merge([
+            'name' => 'Test Site',
+            'domain' => uniqid('test-').'.example.com',
+            'uuid' => \Illuminate\Support\Str::uuid()->toString(),
+            'is_default' => false,
+            'is_active' => true,
+            'domain_verified' => true,
+            'domain_status' => 'verified',
+        ], $attrs));
+    }
+
+    public function test_super_admin_with_no_session_defaults_to_default_site(): void
+    {
+        $defaultSite = $this->makeSite(['is_default' => true, 'name' => 'Main']);
+        $this->makeSite(['name' => 'Other']);
+        $admin = $this->makeSuperAdmin();
+        $this->actingAs($admin);
+        session()->forget('multisite_admin_site_id');
+
+        Livewire::test(DashboardSitePicker::class)
+            ->assertSet('selected', (string) $defaultSite->id);
+
+        $this->assertSame($defaultSite->id, session('multisite_admin_site_id'));
+    }
+
+    public function test_non_super_admin_with_one_site_defaults_to_that_site(): void
+    {
+        $user = $this->makeRegularUser();
+        $site = $this->makeSite(['user_id' => $user->id, 'name' => 'Mine']);
+        $this->actingAs($user);
+        session()->forget('multisite_admin_site_id');
+
+        Livewire::test(DashboardSitePicker::class)
+            ->assertSet('selected', (string) $site->id);
+
+        $this->assertSame($site->id, session('multisite_admin_site_id'));
+    }
+
+    public function test_explicit_specific_site_selection_writes_session_and_dispatches_event(): void
+    {
+        $a = $this->makeSite(['is_default' => true, 'name' => 'A']);
+        $b = $this->makeSite(['name' => 'B']);
+        $this->actingAs($this->makeSuperAdmin());
+
+        Livewire::test(DashboardSitePicker::class)
+            ->set('selected', (string) $b->id)
+            ->assertDispatched('dashboard.site-changed', siteId: $b->id);
+
+        $this->assertSame($b->id, session('multisite_admin_site_id'));
+    }
+
+    public function test_explicit_all_sites_selection_writes_sentinel_and_dispatches_event(): void
+    {
+        $this->makeSite(['is_default' => true]);
+        $this->actingAs($this->makeSuperAdmin());
+
+        Livewire::test(DashboardSitePicker::class)
+            ->set('selected', '__all_sites__')
+            ->assertDispatched('dashboard.site-changed', siteId: '__all_sites__');
+
+        $this->assertSame('__all_sites__', session('multisite_admin_site_id'));
+    }
+
+    public function test_can_view_returns_false_when_user_owns_no_sites(): void
+    {
+        $this->actingAs($this->makeRegularUser());
+
+        $this->assertFalse(DashboardSitePicker::canView());
+    }
+
+    public function test_can_view_returns_true_for_super_admin_even_with_no_owned_sites(): void
+    {
+        $this->actingAs($this->makeSuperAdmin());
+
+        $this->assertTrue(DashboardSitePicker::canView());
+    }
+}

--- a/tests/Feature/Widgets/LicenseStatusWidgetTest.php
+++ b/tests/Feature/Widgets/LicenseStatusWidgetTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Widgets;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+use Tallcms\Multisite\Models\Site;
+use Tests\TestCase;
+
+class LicenseStatusWidgetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! class_exists(\Tallcms\Pro\Filament\Widgets\LicenseStatusWidget::class)) {
+            $this->markTestSkipped('Pro plugin not installed.');
+        }
+
+        if (! class_exists(Site::class)) {
+            $this->markTestSkipped('Multisite plugin not installed.');
+        }
+
+        Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web']);
+    }
+
+    private function makeSuperAdmin(): User
+    {
+        $user = User::create([
+            'name' => 'Boss',
+            'email' => 'boss-'.uniqid().'@example.com',
+            'password' => bcrypt('x'),
+        ]);
+        $user->assignRole('super_admin');
+        $this->actingAs($user);
+
+        return $user;
+    }
+
+    private function makeSite(array $attrs = []): Site
+    {
+        return Site::create(array_merge([
+            'name' => 'Test Site',
+            'domain' => uniqid('test-').'.example.com',
+            'uuid' => \Illuminate\Support\Str::uuid()->toString(),
+            'is_default' => false,
+            'is_active' => true,
+            'domain_verified' => true,
+            'domain_status' => 'verified',
+        ], $attrs));
+    }
+
+    public function test_all_sites_returns_sentinel_status(): void
+    {
+        $this->makeSite(['is_default' => true]);
+        $this->makeSuperAdmin();
+        session(['multisite_admin_site_id' => '__all_sites__']);
+
+        $widget = new \Tallcms\Pro\Filament\Widgets\LicenseStatusWidget();
+        $status = $widget->getStatus();
+
+        $this->assertSame('all_sites', $status['scope']);
+    }
+
+    public function test_can_view_returns_true_on_all_sites_so_empty_state_renders(): void
+    {
+        $this->makeSite(['is_default' => true]);
+        $this->makeSuperAdmin();
+        session(['multisite_admin_site_id' => '__all_sites__']);
+
+        $this->assertTrue(\Tallcms\Pro\Filament\Widgets\LicenseStatusWidget::canView());
+    }
+
+    public function test_all_sites_renders_empty_state_copy(): void
+    {
+        $this->makeSite(['is_default' => true]);
+        $this->makeSuperAdmin();
+        session(['multisite_admin_site_id' => '__all_sites__']);
+
+        Livewire::test(\Tallcms\Pro\Filament\Widgets\LicenseStatusWidget::class)
+            ->assertSee('License status is per-site');
+    }
+
+    public function test_heading_includes_site_name_when_specific_site_selected(): void
+    {
+        $site = $this->makeSite(['name' => 'My Brand', 'is_default' => true]);
+        $this->makeSuperAdmin();
+        session(['multisite_admin_site_id' => $site->id]);
+
+        $widget = new \Tallcms\Pro\Filament\Widgets\LicenseStatusWidget();
+
+        $this->assertSame('License — My Brand', $widget->getHeading());
+    }
+
+    public function test_heading_falls_back_to_plain_label_when_site_id_does_not_resolve(): void
+    {
+        // Session points at a site_id that has no matching row → getMultisiteName
+        // returns null → heading drops the "— Site Name" suffix.
+        session(['multisite_admin_site_id' => 999999]);
+
+        $widget = new \Tallcms\Pro\Filament\Widgets\LicenseStatusWidget();
+
+        $this->assertSame('License', $widget->getHeading());
+    }
+}

--- a/tests/Feature/Widgets/LicenseStatusWidgetTest.php
+++ b/tests/Feature/Widgets/LicenseStatusWidgetTest.php
@@ -23,6 +23,12 @@ class LicenseStatusWidgetTest extends TestCase
             $this->markTestSkipped('Pro plugin not installed.');
         }
 
+        // Skip when Pro is installed at a version that predates the multisite-
+        // aware refactor (v1.10.0+) — older versions don't have getHeading() etc.
+        if (! method_exists(\Tallcms\Pro\Filament\Widgets\LicenseStatusWidget::class, 'getHeading')) {
+            $this->markTestSkipped('Pro plugin too old (need 1.10.0+ for multisite-aware widgets).');
+        }
+
         if (! class_exists(Site::class)) {
             $this->markTestSkipped('Multisite plugin not installed.');
         }


### PR DESCRIPTION
## Summary

Bug surfaced today: ContentHealthWidget shows `5 published posts` on a site the user has 0 posts on. Root cause is **not** in the widget — it's that `SiteSwitcher::navigateToSite()` ([SiteSwitcher.php:47-51 comment](https://github.com/tallcms/tallcms/blob/main/plugins/tallcms/multisite/src/Livewire/SiteSwitcher.php#L47-L51)) explicitly does not mutate `session('multisite_admin_site_id')`. So the session key the widgets filter by was never set by any UI the user touches; widgets always rendered the role-based fallback (super_admin → default site, others → first owned site) regardless of which site the user thought they were on.

The dashboard had no real "current site" concept. This PR adds one.

## What changes

- **New `DashboardSitePicker` widget** at the top of the dashboard (sort -100, full column span). Renders a select with the user's accessible sites (super_admins also see "All Sites"). On selection it writes `session('multisite_admin_site_id')` and dispatches the `dashboard.site-changed` Livewire event.
- **Server-side authorization** on every selection (mount + updatedSelected). `__all_sites__` only valid for super_admins; numeric site_ids must reference an active site that the user owns (super_admins can pick any active site). Tampered Livewire input is rejected without dispatching, and stale unauthorized session values from prior logins are normalized on mount.
- **New `HasMultisiteWidgetContext` trait** (`packages/tallcms/cms/src/Filament/Widgets/Concerns/`). Lifts the byte-for-byte duplicated `getMultisiteSiteId()` / `getMultisiteName()` helpers out of MenuOverviewWidget + ContentHealthWidget and gives a third method `isAllSitesSelected()` for branching on the all-sites case.
- **MenuOverviewWidget + ContentHealthWidget** consume the trait and add `#[On('dashboard.site-changed')]` listeners so they refresh in place when the picker fires.

## Behaviour

Backwards compatible. The picker's `mount()` seeds the session using the **same role-based fallback** the widgets already resolve — so first dashboard load after upgrade matches what users were seeing before, just with a visible scope control they can now change.

| Picker selection | cms widgets (Menu, ContentHealth) |
|---|---|
| Specific site | Filter by that site_id, heading shows `"— Site Name"` |
| All Sites | Show global counts (sum across all rows), heading shows `"— All Sites"` |

The "All Sites → global counts" pattern is intentional for cms widgets where `count(*)` is a meaningful aggregate. Pro analytics + license widgets don't aggregate cleanly across sites, so they get an explicit empty-state branch in the paired Pro plugin PR.

## Why a separate picker (not just wiring SiteSwitcher to write session)

SiteSwitcher's stated job ([comment on lines 47-51](https://github.com/tallcms/tallcms/blob/main/plugins/tallcms/multisite/src/Livewire/SiteSwitcher.php#L47-L51)) is to navigate into a site's edit page; it deliberately doesn't mutate session because authorization there flows through SitePolicy and content scopes through the Site resource's RelationManagers. Hijacking it to also act as a global selector would conflict with that design and ripple into every other consumer of the same session key (`ProSetting::resolveCurrentSiteId`, `PluginLicense::findForCurrentContext`, `SiteSetting`, redirect manager, etc.).

The picker keeps both concepts honest: SiteSwitcher = navigate; DashboardSitePicker = scope.

## Test plan

- [x] `cd packages/tallcms/cms && vendor/bin/phpunit --filter=HasMultisiteWidgetContext` — 11 assertions pass (all branches of getMultisiteSiteId / getMultisiteName / isAllSitesSelected).
- [x] `php artisan test --filter='DashboardSitePicker'` — 11 picker tests / 20 assertions pass: default-site seeding for super_admin, single-owned-site seeding for regular user, explicit specific-site selection writes session + dispatches event, explicit `__all_sites__` selection same, canView truthiness, **regular user cannot select another user's site / `__all_sites__` / inactive site, mount normalizes stale foreign-user session value, mount rejects stale `__all_sites__` for non-super-admin**.
- [x] `php artisan test --filter='MenuOverviewWidget|ContentHealthWidget'` — existing tests still green after trait extraction.
- [x] `php artisan test --filter='AnalyticsOverviewWidget|LicenseStatusWidget'` — 10 Pro widget tests / 20 assertions pass (when paired Pro PR is checked out via the symlinked plugin).
- [x] `cd packages/tallcms/cms && vendor/bin/phpunit` — full package suite green (589 tests).
- [ ] Manual: load `/admin` as super_admin, picker shows at the top. Switch picker to an empty site → ContentHealth shows `0 published posts` with heading `"Content Health — Site Name"`. Switch to "All Sites" → cms widgets show global counts. Verify no full page reload.

## Follow-up

Paired Pro plugin PR (tallcms-pro-plugin#2, depends on this merging + a tallcms/cms tag) ports AnalyticsOverviewWidget and LicenseStatusWidget to use the trait, listen for `dashboard.site-changed`, and render an empty-state message under `__all_sites__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)