### PR TITLE
Shield-gate the RegistrationSettings page

### DIFF
--- a/app/Filament/Pages/RegistrationSettings.php
+++ b/app/Filament/Pages/RegistrationSettings.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Pages;
+
+use BezhanSalleh\FilamentShield\Traits\HasPageShield;
+use Tallcms\FilamentRegistration\Filament\Pages\RegistrationSettings as BasePage;
+
+/**
+ * Host-defined Shield-gated subclass of the package's registration settings.
+ *
+ * The package ships a deliberately Shield-agnostic page so it doesn't force
+ * every consumer to depend on bezhansalleh/filament-shield. We add the trait
+ * here in the host app and swap this subclass in via
+ * Tallcms\Registration\Filament\RegistrationPlugin::settingsPage(), which
+ * forwards to FilamentRegistrationPlugin::settingsPage() (added in package
+ * v1.2.0).
+ *
+ * Permission: View:RegistrationSettings (auto-discovered by Shield's
+ * generate command from this class name).
+ */
+class RegistrationSettings extends BasePage
+{
+    use HasPageShield;
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -99,8 +99,12 @@ class AdminPanelProvider extends PanelProvider
                 TallCmsPlugin::make(),
                 // Registration bridge ships as a local plugin under /plugins/tallcms/registration/.
                 // Guard so fresh checkouts (CI release builds, plugin-mode users) without the
-                // plugin installed don't crash on a missing class reference.
-                class_exists(TallcmsRegistrationBridge::class) ? TallcmsRegistrationBridge::make() : null,
+                // plugin installed don't crash on a missing class reference. settingsPage()
+                // swaps in the host-defined Shield-gated subclass so the panel page enforces
+                // View:RegistrationSettings instead of being open to anyone with admin access.
+                class_exists(TallcmsRegistrationBridge::class)
+                    ? TallcmsRegistrationBridge::make()->settingsPage(\App\Filament\Pages\RegistrationSettings::class)
+                    : null,
             ]))
             ->authMiddleware([
                 Authenticate::class,

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "livewire/livewire": "^4.0",
         "symfony/yaml": "^7.4",
         "tallcms/cms": "^4.0",
-        "tallcms/filament-registration": "^1.0"
+        "tallcms/filament-registration": "^1.2"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd40f330ca8fc3064fd4d3b12a7bcc9b",
+    "content-hash": "3cfcf27fa06106297084b3ee7ec21779",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -9082,16 +9082,16 @@
         },
         {
             "name": "tallcms/filament-registration",
-            "version": "1.1.3",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tallcms/filament-registration.git",
-                "reference": "7a050ef77e655faeadec6291ed17f71bb927ef36"
+                "reference": "0049fb84918fcade457b917ca23db19aa9643eab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tallcms/filament-registration/zipball/7a050ef77e655faeadec6291ed17f71bb927ef36",
-                "reference": "7a050ef77e655faeadec6291ed17f71bb927ef36",
+                "url": "https://api.github.com/repos/tallcms/filament-registration/zipball/0049fb84918fcade457b917ca23db19aa9643eab",
+                "reference": "0049fb84918fcade457b917ca23db19aa9643eab",
                 "shasum": ""
             },
             "require": {
@@ -9148,7 +9148,7 @@
                 "issues": "https://github.com/tallcms/filament-registration/issues",
                 "source": "https://github.com/tallcms/filament-registration"
             },
-            "time": "2026-04-27T06:49:31+00:00"
+            "time": "2026-04-30T08:21:29+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",


### PR DESCRIPTION
## Summary

The \`tallcms/filament-registration\` package ships its \`RegistrationSettings\` page intentionally without Shield (so the package stays Shield-optional for consumers who don't use \`bezhansalleh/filament-shield\`). Without further wiring, that page sat on the admin panel accessible to anyone who could log in — \`View:RegistrationSettings\` permission rows in the DB were unread.

Same pattern as the Pro plugin v1.8.2 fix for \`ProSettings\`. Subclass the package's page in the host app, mix in \`HasPageShield\`, swap it in via the plugin's new \`settingsPage()\` setter.

## Three coordinated changes

1. **tallcms/filament-registration v1.2.0** (already released): adds \`FilamentRegistrationPlugin::settingsPage()\` that takes a \`class-string<RegistrationSettings>\` subclass, validates inheritance, and registers it instead of the default page.
2. **\`/plugins/tallcms/registration\` bridge plugin** (in the gitignored local plugin tree): forwards a \`settingsPage()\` call through to the underlying \`FilamentRegistrationPlugin\` so the host can configure it without bypassing the bridge (which also sets \`defaultRole\` from config).
3. **\`App\\Filament\\Pages\\RegistrationSettings\`**: subclass with \`HasPageShield\`. \`AdminPanelProvider\` wires it via:

   \`\`\`php
   TallcmsRegistrationBridge::make()
       ->settingsPage(\\App\\Filament\\Pages\\RegistrationSettings::class)
   \`\`\`

Bumps the \`composer.json\` constraint to \`^1.2\` to require the new setter.

## Why it stayed broken until now

\`shield:generate\` auto-discovers pages and creates \`View:RegistrationSettings\` permission rows. But the page itself never reads them — without \`HasPageShield\`, there's no \`canAccess()\` or \`shouldRegisterNavigation()\` check. So toggling the permission in the Shield UI saved to the DB and had no effect. Same shape as the ProSettings gap fixed in tallcms/pro v1.8.2.

## Upgrade notes

- \`composer install\` after pulling — picks up filament-registration 1.2.0.
- After deploy: \`php artisan shield:generate\` to seed \`View:RegistrationSettings\` for existing roles.
- Audit role assignments — site_owner / site_user / similar roles need \`View:RegistrationSettings\` granted explicitly if they should keep access. Super_admins bypass Shield and continue to access unchanged.


\`\`\`php
FilamentRegistrationPlugin::make()
    ->defaultRole('site_owner')
    ->settingsPage(\\App\\Filament\\Pages\\RegistrationSettings::class)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)