### PR TITLE
Gate ThemeManager destructive + license actions to super_admin

### DIFF
--- a/packages/tallcms/cms/src/Filament/Pages/ThemeManager.php
+++ b/packages/tallcms/cms/src/Filament/Pages/ThemeManager.php
@@ -923,6 +923,8 @@ class ThemeManager extends Page implements HasForms
             ->label('Activate License')
             ->icon('heroicon-o-key')
             ->color('primary')
+            ->visible(fn () => auth()->user()?->hasRole('super_admin') ?? false)
+            ->authorize(fn () => auth()->user()?->hasRole('super_admin') ?? false)
             ->modalHeading(fn (array $arguments) => "Activate License — {$arguments['name']}")
             ->modalDescription('Enter your license key from your purchase email.')
             ->form([
@@ -932,6 +934,17 @@ class ThemeManager extends Page implements HasForms
                     ->required(),
             ])
             ->action(function (array $data, array $arguments) {
+                // Server-side guard: theme licenses are installation-wide, super_admin only.
+                if (! auth()->user()?->hasRole('super_admin')) {
+                    Notification::make()
+                        ->title('Not authorized')
+                        ->body('Only super admins can activate theme licenses.')
+                        ->danger()
+                        ->send();
+
+                    return;
+                }
+
                 $result = app(PluginLicenseService::class)->activate(
                     $arguments['licenseSlug'],
                     $data['license_key']
@@ -972,11 +985,24 @@ class ThemeManager extends Page implements HasForms
             ->label('Deactivate')
             ->icon('heroicon-o-x-circle')
             ->color('danger')
+            ->visible(fn () => auth()->user()?->hasRole('super_admin') ?? false)
+            ->authorize(fn () => auth()->user()?->hasRole('super_admin') ?? false)
             ->requiresConfirmation()
             ->modalHeading(fn (array $arguments) => "Deactivate License — {$arguments['name']}")
             ->modalDescription('Are you sure you want to deactivate this license? The theme may lose access to updates and premium features.')
             ->modalSubmitActionLabel('Yes, Deactivate')
             ->action(function (array $arguments) {
+                // Server-side guard: theme licenses are installation-wide, super_admin only.
+                if (! auth()->user()?->hasRole('super_admin')) {
+                    Notification::make()
+                        ->title('Not authorized')
+                        ->body('Only super admins can deactivate theme licenses.')
+                        ->danger()
+                        ->send();
+
+                    return;
+                }
+
                 $result = app(PluginLicenseService::class)->deactivate($arguments['licenseSlug']);
 
                 if ($result['success']) {
@@ -1018,7 +1044,20 @@ class ThemeManager extends Page implements HasForms
                 ->label('Refresh Licenses')
                 ->icon('heroicon-o-key')
                 ->color('gray')
+                ->visible(fn () => auth()->user()?->hasRole('super_admin') ?? false)
+                ->authorize(fn () => auth()->user()?->hasRole('super_admin') ?? false)
                 ->action(function () {
+                    // Server-side guard: cache-busting installation-wide license state, super_admin only.
+                    if (! auth()->user()?->hasRole('super_admin')) {
+                        Notification::make()
+                            ->title('Not authorized')
+                            ->body('Only super admins can refresh theme license status.')
+                            ->danger()
+                            ->send();
+
+                        return;
+                    }
+
                     $licenseService = app(PluginLicenseService::class);
                     $licenseService->clearCache();
 

--- a/packages/tallcms/cms/src/Filament/Pages/ThemeManager.php
+++ b/packages/tallcms/cms/src/Filament/Pages/ThemeManager.php
@@ -794,11 +794,24 @@ class ThemeManager extends Page implements HasForms
             ->label('Delete')
             ->icon('heroicon-o-trash')
             ->color('danger')
+            ->visible(fn () => auth()->user()?->hasRole('super_admin') ?? false)
+            ->authorize(fn () => auth()->user()?->hasRole('super_admin') ?? false)
             ->requiresConfirmation()
             ->modalHeading('Delete Theme')
             ->modalDescription(fn (array $arguments) => "Are you sure you want to delete the theme '{$arguments['name']}'? This action cannot be undone.")
             ->modalSubmitActionLabel('Yes, Delete Theme')
             ->action(function (array $arguments) {
+                // Server-side guard: themes are installation-wide, super_admin only.
+                if (! auth()->user()?->hasRole('super_admin')) {
+                    Notification::make()
+                        ->title('Not authorized')
+                        ->body('Only super admins can delete themes.')
+                        ->danger()
+                        ->send();
+
+                    return;
+                }
+
                 $slug = $arguments['slug'];
                 $theme = Theme::find($slug);
 
@@ -1030,12 +1043,14 @@ class ThemeManager extends Page implements HasForms
                 ->color('gray')
                 ->action(fn () => $this->refreshThemes()),
 
-            // Theme Upload action
+            // Theme Upload action — gated to super_admin (installation-wide concern)
+            // AND the theme.allow_uploads config flag.
             Action::make('upload')
                 ->label('Upload Theme')
                 ->icon('heroicon-o-arrow-up-tray')
                 ->color('primary')
-                ->visible(fn () => config('theme.allow_uploads', false))
+                ->visible(fn () => config('theme.allow_uploads', false) && (auth()->user()?->hasRole('super_admin') ?? false))
+                ->authorize(fn () => auth()->user()?->hasRole('super_admin') ?? false)
                 ->form([
                     FileUpload::make('theme_zip')
                         ->label('Theme Package (ZIP)')
@@ -1047,7 +1062,19 @@ class ThemeManager extends Page implements HasForms
                         ->helperText('Upload a theme package (.zip file). Maximum size: 50MB.'),
                 ])
                 ->action(function (array $data) {
-                    // Server-side guard: verify uploads are enabled (visible() is UI-only)
+                    // Server-side guards: super_admin only AND uploads enabled.
+                    // Both checks run regardless of UI state in case the action is
+                    // invoked via direct AJAX bypassing visible().
+                    if (! auth()->user()?->hasRole('super_admin')) {
+                        Notification::make()
+                            ->title('Not authorized')
+                            ->body('Only super admins can upload themes.')
+                            ->danger()
+                            ->send();
+
+                        return;
+                    }
+
                     if (! config('theme.allow_uploads', false)) {
                         Notification::make()
                             ->title('Uploads disabled')


### PR DESCRIPTION
## Summary

Reported: site owners (non-super-admin users) on multisite installs have the **Delete** and **Upload Theme** buttons available on the Theme Manager page. After investigating, the same gap also affected the three license-related actions on the same page. This PR closes all five.

The page itself uses \`HasPageShield\`, so \`View:ThemeManager\` gates page access — and site owners *do* need that permission so they can switch which theme is active for their site. But the actions on it had no per-action authorization, so anyone who could see the page could trigger them.

## What changed

Five actions now gated to super_admin via three layers (UI hide + backend block + defensive in-body check):

| Action | Was | Now |
|---|---|---|
| \`delete\` | Open to anyone with view permission | super_admin only |
| \`upload\` | Gated only on \`theme.allow_uploads\` config flag | super_admin AND \`theme.allow_uploads\` |
| \`activateLicense\` | Open to anyone with view permission | super_admin only |
| \`deactivateLicense\` | Open to anyone with view permission | super_admin only |
| \`refreshAllLicenses\` | Open to anyone with view permission | super_admin only |

Each gets:
1. \`->visible(...)\` — UI hide
2. \`->authorize(...)\` — backend block for direct AJAX invocation
3. Defensive role check + \`Notification\` fallback inside the action body

All gates use \`auth()->user()->hasRole('super_admin')\` — matching how super_admins bypass Shield checks elsewhere. Tallcms's install command marks the first user as super_admin so single-site installs continue to work without further role assignment.

## Pattern note

This is the same kind of gap as v1.8.2 ProSettings and #79 RegistrationSettings, but at the action level rather than the page level. The broader pattern — page-level Shield being insufficient once any role with valid view permission exists — is worth a once-over across the rest of the admin panel. Worth a follow-up audit PR; the most likely affected places are pages that mix \"editor view\" content with \"installation admin\" actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)