### PR TITLE
Preserve Site → Page navigation context across CmsPage edit/create

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8993,11 +8993,11 @@
         },
         {
             "name": "tallcms/cms",
-            "version": "4.4.7",
+            "version": "4.4.8",
             "dist": {
                 "type": "path",
                 "url": "./packages/tallcms/cms",
-                "reference": "1254b95ef4b79f638b408cb662a3aa687596f332"
+                "reference": "59a7ba59be9a616428784ae35209ae6c1842cfd9"
             },
             "require": {
                 "bezhansalleh/filament-shield": "^4.0",

--- a/packages/tallcms/cms/composer.json
+++ b/packages/tallcms/cms/composer.json
@@ -2,7 +2,7 @@
     "$schema": "https://getcomposer.org/schema.json",
     "name": "tallcms/cms",
     "type": "library",
-    "version": "4.4.7",
+    "version": "4.4.8",
     "description": "TallCMS - A modern CMS for Filament admin panels. Works standalone or as a plugin in existing Filament apps.",
     "keywords": [
         "cms",

--- a/packages/tallcms/cms/src/Filament/Concerns/HasFromSiteContext.php
+++ b/packages/tallcms/cms/src/Filament/Concerns/HasFromSiteContext.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TallCms\Cms\Filament\Concerns;
+
+use Filament\Actions\Action;
+use TallCms\Cms\Filament\Resources\SiteResource\SiteResource as CoreSiteResource;
+use TallCms\Cms\Models\CmsPage;
+use TallCms\Cms\Models\Site;
+
+/**
+ * Preserves site navigation context across the CmsPage edit/create flow.
+ *
+ * When a user enters the page editor from a Site relation manager (Sites
+ * → Pages → Edit), the receiving page captures `?from_site=<id>` at
+ * mount() and threads it through the rest of the lifecycle as a Livewire
+ * property. After save / delete the user is sent back to the originating
+ * Site edit page instead of the global Pages index — preserving the
+ * site-context the user was working in.
+ *
+ * The query param is read ONCE in mount(); afterward the captured
+ * property is durable across Livewire `/livewire/update` round trips
+ * (which don't carry the original query string). The trait stays inert
+ * on single-site installs — its first guard checks
+ * CmsPage::hasSiteIdColumn(), which is false when the multisite plugin
+ * isn't installed.
+ */
+trait HasFromSiteContext
+{
+    /**
+     * Captured at mount() from the `from_site` query param. Null when not
+     * provided, when the column doesn't exist (single-site install), or
+     * when the value can't be parsed as a positive integer.
+     */
+    public ?int $fromSiteId = null;
+
+    protected function captureFromSite(): void
+    {
+        if (! CmsPage::hasSiteIdColumn()) {
+            return;
+        }
+
+        $param = request()->query('from_site');
+        if (is_numeric($param) && (int) $param > 0) {
+            $this->fromSiteId = (int) $param;
+        }
+    }
+
+    /**
+     * Returns the validated from_site id when navigation context is real,
+     * else null. Validation prefers the loaded record's site_id (post-save
+     * reality) and falls back to a CreateCmsPage's $ownerSiteId before the
+     * record is persisted, so the create-page back-action can render
+     * before the user clicks Save.
+     */
+    protected function pendingFromSiteId(): ?int
+    {
+        if ($this->fromSiteId === null) {
+            return null;
+        }
+
+        // Local safe read — Filament's CreateRecord may not initialise the
+        // typed $record property until after fill, so reading it directly
+        // could throw "Typed property must not be accessed before
+        // initialization." The null-safe coalesce sidesteps that.
+        $record = $this->record ?? null;
+
+        if ($record?->site_id !== null) {
+            return (int) $record->site_id === $this->fromSiteId
+                ? $this->fromSiteId
+                : null;
+        }
+
+        // CreateCmsPage path before save: $record is unsaved (no site_id
+        // yet) but $ownerSiteId is already populated from ?site=N. The
+        // trait reaches into $this->ownerSiteId by name; for EditCmsPage
+        // (no such property) the null-coalesce falls through to null,
+        // which is correct because Edit always has a record.
+        $ownerSiteId = $this->ownerSiteId ?? null;
+
+        return $ownerSiteId !== null && (int) $ownerSiteId === $this->fromSiteId
+            ? $this->fromSiteId
+            : null;
+    }
+
+    protected function fromSiteUrl(): ?string
+    {
+        $id = $this->pendingFromSiteId();
+        if ($id === null) {
+            return null;
+        }
+
+        // class_exists alone isn't enough — the class can autoload but its
+        // routes might not be registered in the active panel (e.g. a host
+        // that called $plugin->withoutSiteSettings(), or didn't include
+        // the multisite plugin in its panel). The try/catch is the
+        // graceful-degradation safety net: if a candidate's routes aren't
+        // registered, getUrl() throws and we try the next.
+        $candidates = [
+            CoreSiteResource::class,
+            'Tallcms\\Multisite\\Filament\\Resources\\SiteResource\\SiteResource',
+        ];
+
+        foreach ($candidates as $resource) {
+            if (! class_exists($resource)) {
+                continue;
+            }
+            try {
+                return $resource::getUrl('edit', ['record' => $id]);
+            } catch (\Throwable) {
+                continue;
+            }
+        }
+
+        return null;
+    }
+
+    protected function fromSiteName(): ?string
+    {
+        $id = $this->pendingFromSiteId();
+        if ($id === null) {
+            return null;
+        }
+
+        return Site::find($id)?->name;
+    }
+
+    /**
+     * Returns the "Back to site" header action when navigation context is
+     * present, else null. Callers spread the return into getHeaderActions()
+     * via array_filter() so a null silently drops out of the action list
+     * on installs where context isn't applicable.
+     */
+    protected function getBackToSiteAction(): ?Action
+    {
+        $url = $this->fromSiteUrl();
+        if ($url === null) {
+            return null;
+        }
+
+        return Action::make('back_to_site')
+            ->label('Back to site')
+            ->icon('heroicon-m-arrow-left')
+            ->color('gray')
+            ->url($url);
+    }
+}

--- a/packages/tallcms/cms/src/Filament/Resources/CmsPages/Pages/CreateCmsPage.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsPages/Pages/CreateCmsPage.php
@@ -5,10 +5,12 @@ namespace TallCms\Cms\Filament\Resources\CmsPages\Pages;
 use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Support\Facades\Schema;
 use LaraZeus\SpatieTranslatable\Resources\Pages\CreateRecord\Concerns\Translatable;
+use TallCms\Cms\Filament\Concerns\HasFromSiteContext;
 use TallCms\Cms\Filament\Resources\CmsPages\CmsPageResource;
 
 class CreateCmsPage extends CreateRecord
 {
+    use HasFromSiteContext;
     use Translatable;
 
     protected static string $resource = CmsPageResource::class;
@@ -30,6 +32,21 @@ class CreateCmsPage extends CreateRecord
         if ($siteParam !== null && is_numeric($siteParam)) {
             $this->ownerSiteId = (int) $siteParam;
         }
+
+        $this->captureFromSite();
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return array_filter([
+            $this->getBackToSiteAction(),
+            ...parent::getHeaderActions(),
+        ]);
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->fromSiteUrl() ?? parent::getRedirectUrl();
     }
 
     /**

--- a/packages/tallcms/cms/src/Filament/Resources/CmsPages/Pages/EditCmsPage.php
+++ b/packages/tallcms/cms/src/Filament/Resources/CmsPages/Pages/EditCmsPage.php
@@ -15,21 +15,43 @@ use Filament\Resources\Pages\EditRecord;
 use Illuminate\Support\Facades\Schema;
 use LaraZeus\SpatieTranslatable\Actions\LocaleSwitcher;
 use LaraZeus\SpatieTranslatable\Resources\Pages\EditRecord\Concerns\Translatable;
+use TallCms\Cms\Filament\Concerns\HasFromSiteContext;
 use TallCms\Cms\Filament\Concerns\HasTranslationCopying;
 use TallCms\Cms\Filament\Resources\CmsPages\CmsPageResource;
 use TallCms\Cms\Services\PublishingWorkflowService;
 
 class EditCmsPage extends EditRecord
 {
+    use HasFromSiteContext;
     use HasTranslationCopying, Translatable {
         HasTranslationCopying::updatedActiveLocale insteadof Translatable;
     }
 
     protected static string $resource = CmsPageResource::class;
 
+    public function mount(int|string $record): void
+    {
+        parent::mount($record);
+        $this->captureFromSite();
+    }
+
+    public function getSubheading(): ?string
+    {
+        $name = $this->fromSiteName();
+
+        return $name ? "Editing within site: {$name}" : null;
+    }
+
+    protected function getRedirectUrl(): ?string
+    {
+        return $this->fromSiteUrl() ?? parent::getRedirectUrl();
+    }
+
     protected function getHeaderActions(): array
     {
-        return [
+        return array_values(array_filter([
+            $this->getBackToSiteAction(),
+
             // Locale Switcher for translations
             LocaleSwitcher::make(),
 
@@ -71,10 +93,12 @@ class EditCmsPage extends EditRecord
             $this->getSaveSnapshotAction(),
             $this->getMarkAsReviewedAction(),
 
-            DeleteAction::make(),
-            ForceDeleteAction::make(),
+            DeleteAction::make()
+                ->successRedirectUrl(fn () => $this->fromSiteUrl() ?? CmsPageResource::getUrl('index')),
+            ForceDeleteAction::make()
+                ->successRedirectUrl(fn () => $this->fromSiteUrl() ?? CmsPageResource::getUrl('index')),
             RestoreAction::make(),
-        ];
+        ]));
     }
 
     protected function getMarkAsReviewedAction(): Action

--- a/packages/tallcms/cms/src/Filament/Resources/SiteResource/RelationManagers/PagesRelationManager.php
+++ b/packages/tallcms/cms/src/Filament/Resources/SiteResource/RelationManagers/PagesRelationManager.php
@@ -54,19 +54,26 @@ class PagesRelationManager extends RelationManager
                 Action::make('create_page')
                     ->label('Create Page')
                     ->icon('heroicon-m-plus')
-                    ->action(function () {
-                        // Set admin context to this site before redirecting
-                        $siteId = $this->getOwnerRecord()->id;
-                        session(['multisite_admin_site_id' => $siteId]);
-
-                        $this->redirect(CmsPageResource::getUrl('create'));
-                    }),
+                    // ?site=<id> sets site_id explicitly on save; ?from_site=<id>
+                    // is the navigation breadcrumb that lands the user back on
+                    // this Site after save instead of the global Pages index.
+                    // Both query params are URL-explicit so the post-save
+                    // redirect survives the Livewire round trip — session
+                    // state alone wouldn't (mid-request session writes don't
+                    // always reach the redirect target reliably).
+                    ->url(fn () => CmsPageResource::getUrl('create', [
+                        'site' => $this->getOwnerRecord()->id,
+                        'from_site' => $this->getOwnerRecord()->id,
+                    ])),
             ])
             ->recordActions([
                 Action::make('edit')
                     ->label('Edit')
                     ->icon('heroicon-m-pencil-square')
-                    ->url(fn ($record) => CmsPageResource::getUrl('edit', ['record' => $record])),
+                    ->url(fn ($record) => CmsPageResource::getUrl('edit', [
+                        'record' => $record,
+                        'from_site' => $this->getOwnerRecord()->id,
+                    ])),
             ]);
     }
 }

--- a/packages/tallcms/cms/src/Models/CmsPage.php
+++ b/packages/tallcms/cms/src/Models/CmsPage.php
@@ -86,6 +86,7 @@ class CmsPage extends Model implements HasRichContent
     protected $casts = [
         'content' => TranslatableArray::class,
         'sidebar_widgets' => 'array',
+        'site_id' => 'integer',
         'published_at' => 'datetime',
         'is_homepage' => 'boolean',
         'show_breadcrumbs' => 'boolean',
@@ -94,6 +95,11 @@ class CmsPage extends Model implements HasRichContent
         'last_reviewed_at' => 'datetime',
         'sources' => 'array',
     ];
+
+    public function site(): BelongsTo
+    {
+        return $this->belongsTo(Site::class, 'site_id');
+    }
 
     protected function setUpRichContent(): void
     {
@@ -130,7 +136,7 @@ class CmsPage extends Model implements HasRichContent
      */
     protected static ?bool $hasSiteIdColumn = null;
 
-    protected static function hasSiteIdColumn(): bool
+    public static function hasSiteIdColumn(): bool
     {
         return static::$hasSiteIdColumn ??= Schema::hasColumn('tallcms_pages', 'site_id');
     }
@@ -187,8 +193,8 @@ class CmsPage extends Model implements HasRichContent
      * just the leaf slug stored in the database ("team"), preserving the
      * pre-hierarchical URL behavior for existing installs.
      *
-     * @param  string|null  $locale   Locale for translatable slugs (null = current app locale)
-     * @param  array<int>   $visited  Internal cycle guard — do not pass from call sites
+     * @param  string|null  $locale  Locale for translatable slugs (null = current app locale)
+     * @param  array<int>  $visited  Internal cycle guard — do not pass from call sites
      */
     public function getFullSlug(?string $locale = null, array $visited = []): string
     {

--- a/packages/tallcms/cms/tests/Feature/Filament/CmsPageFromSiteContextTest.php
+++ b/packages/tallcms/cms/tests/Feature/Filament/CmsPageFromSiteContextTest.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace TallCms\Cms\Tests\Feature\Filament;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use ReflectionClass;
+use TallCms\Cms\Filament\Concerns\HasFromSiteContext;
+use TallCms\Cms\Models\CmsPage;
+use TallCms\Cms\Models\Site;
+use TallCms\Cms\Tests\TestCase;
+
+/**
+ * Covers the trait that preserves Site → Page navigation context across
+ * the Filament edit/create lifecycle.
+ *
+ * The failure mode the trait exists to prevent: reading from request()
+ * inside save / delete / redirect lifecycle hooks would silently drop
+ * the from_site value because Livewire action requests go through
+ * /livewire/update, which has no access to the original page URL's
+ * query string. The trait captures the param ONCE in mount() into a
+ * Livewire public property; everything afterward reads the property.
+ *
+ * The first test pins the non-multisite safety guarantee — when
+ * CmsPage::hasSiteIdColumn() returns false, the trait returns null
+ * at every resolution point regardless of input. Single-site installs
+ * see identical behaviour to before this feature shipped.
+ */
+class CmsPageFromSiteContextTest extends TestCase
+{
+    protected function defineDatabaseMigrations(): void
+    {
+        parent::defineDatabaseMigrations();
+
+        Schema::create('tallcms_pages', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('site_id')->nullable();
+            $table->json('title');
+            $table->json('slug');
+            $table->json('content')->nullable();
+            $table->text('search_content')->nullable();
+            $table->string('status')->default('draft');
+            $table->boolean('is_homepage')->default(false);
+            $table->unsignedBigInteger('parent_id')->nullable();
+            $table->integer('sort_order')->default(0);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('tallcms_sites', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('domain')->nullable();
+            $table->string('uuid')->nullable();
+            $table->boolean('is_default')->default(false);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+
+        Schema::create('tallcms_revisions', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('revisionable');
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->text('title');
+            $table->text('excerpt')->nullable();
+            $table->json('content')->nullable();
+            $table->text('meta_title')->nullable();
+            $table->text('meta_description')->nullable();
+            $table->string('featured_image')->nullable();
+            $table->json('additional_data')->nullable();
+            $table->unsignedInteger('revision_number');
+            $table->text('notes')->nullable();
+            $table->string('content_hash')->nullable();
+            $table->boolean('is_manual')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Returns a fresh anonymous instance that mixes in HasFromSiteContext.
+     * The two public properties match the Livewire surface of EditCmsPage
+     * (record only) or CreateCmsPage (record + ownerSiteId). Trait methods
+     * are aliased to public so the assertion-level tests can call them
+     * directly without going through a wrapper.
+     */
+    protected function makeHolder(?CmsPage $record = null, ?int $ownerSiteId = null): object
+    {
+        $holder = new class
+        {
+            use HasFromSiteContext {
+                captureFromSite as public;
+                pendingFromSiteId as public;
+                fromSiteUrl as public;
+                fromSiteName as public;
+                getBackToSiteAction as public;
+            }
+
+            public mixed $record = null;
+
+            public ?int $ownerSiteId = null;
+        };
+
+        $holder->record = $record;
+        $holder->ownerSiteId = $ownerSiteId;
+
+        return $holder;
+    }
+
+    /**
+     * Resets the per-process schema cache between tests so a test that
+     * forces hasSiteIdColumn=false doesn't leak that state into siblings.
+     */
+    protected function tearDown(): void
+    {
+        $this->resetHasSiteIdColumnCache();
+
+        parent::tearDown();
+    }
+
+    protected function resetHasSiteIdColumnCache(?bool $value = null): void
+    {
+        $reflection = new ReflectionClass(CmsPage::class);
+        $property = $reflection->getProperty('hasSiteIdColumn');
+        $property->setAccessible(true);
+        $property->setValue(null, $value);
+    }
+
+    public function test_single_site_install_keeps_trait_inert(): void
+    {
+        // Force the column-detection cache to the "single-site" answer
+        // without dropping the actual schema (which other tests share).
+        $this->resetHasSiteIdColumnCache(false);
+
+        request()->query->set('from_site', '7');
+
+        $holder = $this->makeHolder();
+        $holder->captureFromSite();
+
+        $this->assertNull(
+            $holder->fromSiteId,
+            'captureFromSite must short-circuit when site_id column is absent.'
+        );
+        $this->assertNull($holder->pendingFromSiteId());
+        $this->assertNull($holder->fromSiteUrl());
+        $this->assertNull($holder->fromSiteName());
+        $this->assertNull($holder->getBackToSiteAction());
+    }
+
+    public function test_capture_from_site_records_query_param(): void
+    {
+        request()->query->set('from_site', '7');
+
+        $holder = $this->makeHolder();
+        $holder->captureFromSite();
+
+        $this->assertSame(7, $holder->fromSiteId);
+    }
+
+    public function test_capture_from_site_ignores_non_numeric_input(): void
+    {
+        request()->query->set('from_site', 'haha');
+
+        $holder = $this->makeHolder();
+        $holder->captureFromSite();
+
+        $this->assertNull($holder->fromSiteId);
+    }
+
+    public function test_capture_from_site_ignores_zero_or_negative(): void
+    {
+        request()->query->set('from_site', '0');
+        $holder = $this->makeHolder();
+        $holder->captureFromSite();
+        $this->assertNull($holder->fromSiteId);
+
+        request()->query->set('from_site', '-3');
+        $holder = $this->makeHolder();
+        $holder->captureFromSite();
+        $this->assertNull($holder->fromSiteId);
+    }
+
+    public function test_edit_path_validates_against_record_site_id(): void
+    {
+        $page = CmsPage::create([
+            'site_id' => 7,
+            'title' => ['en' => 'p'],
+            'slug' => ['en' => 'p'],
+            'status' => 'draft',
+        ]);
+
+        $holder = $this->makeHolder(record: $page);
+        $holder->fromSiteId = 7;
+
+        $this->assertSame(7, $holder->pendingFromSiteId());
+    }
+
+    public function test_edit_path_rejects_mismatched_record_site_id(): void
+    {
+        $page = CmsPage::create([
+            'site_id' => 7,
+            'title' => ['en' => 'p'],
+            'slug' => ['en' => 'p'],
+            'status' => 'draft',
+        ]);
+
+        // Spoofed query: page belongs to site 7, attacker passes from_site=99.
+        $holder = $this->makeHolder(record: $page);
+        $holder->fromSiteId = 99;
+
+        $this->assertNull($holder->pendingFromSiteId());
+    }
+
+    public function test_create_path_validates_against_owner_site_id_pre_save(): void
+    {
+        // CreateCmsPage before save: $record is unsaved (treated here as null
+        // since Filament's CreateRecord may not initialise $record yet).
+        // $ownerSiteId carries the captured ?site=N value.
+        $holder = $this->makeHolder(record: null, ownerSiteId: 7);
+        $holder->fromSiteId = 7;
+
+        $this->assertSame(
+            7,
+            $holder->pendingFromSiteId(),
+            'Pre-save resolution must validate against ownerSiteId so the back action renders before the user clicks Save.'
+        );
+    }
+
+    public function test_create_path_rejects_mismatched_owner_site_id(): void
+    {
+        // Spoofed: ?site=7&from_site=99 — the user came in claiming site 99
+        // but the page they're creating belongs to site 7. Reject.
+        $holder = $this->makeHolder(record: null, ownerSiteId: 7);
+        $holder->fromSiteId = 99;
+
+        $this->assertNull($holder->pendingFromSiteId());
+    }
+
+    public function test_eloquent_string_site_id_does_not_break_strict_equality(): void
+    {
+        // If a host removes the int cast, Eloquent may surface site_id as a
+        // string. The trait casts both sides explicitly so the validation
+        // still passes. This test pins that defence.
+        $page = new CmsPage([
+            'site_id' => '7', // string on purpose
+            'title' => ['en' => 'p'],
+            'slug' => ['en' => 'p'],
+            'status' => 'draft',
+        ]);
+
+        $holder = $this->makeHolder(record: $page);
+        $holder->fromSiteId = 7;
+
+        $this->assertSame(7, $holder->pendingFromSiteId());
+    }
+
+    public function test_from_site_name_resolves_via_site_model(): void
+    {
+        Site::create([
+            'name' => 'Chuan Grove',
+            'domain' => 'chuan-grove.example.com',
+            'is_default' => false,
+            'is_active' => true,
+        ]);
+        $siteId = (int) Site::where('name', 'Chuan Grove')->value('id');
+
+        $page = CmsPage::create([
+            'site_id' => $siteId,
+            'title' => ['en' => 'p'],
+            'slug' => ['en' => 'p'],
+            'status' => 'draft',
+        ]);
+
+        $holder = $this->makeHolder(record: $page);
+        $holder->fromSiteId = $siteId;
+
+        $this->assertSame('Chuan Grove', $holder->fromSiteName());
+    }
+
+    public function test_from_site_url_returns_null_when_no_site_resource_registered(): void
+    {
+        // The cms-package test suite doesn't register any Filament panel,
+        // so no SiteResource has routes wired. fromSiteUrl()'s try/catch
+        // around getUrl() should swallow the failure and return null —
+        // proving the graceful-degradation path. (When the multisite or
+        // cms-core panel IS registered, getUrl produces a real URL; that
+        // path is exercised by the standalone monorepo's Filament tests.)
+        $page = CmsPage::create([
+            'site_id' => 7,
+            'title' => ['en' => 'p'],
+            'slug' => ['en' => 'p'],
+            'status' => 'draft',
+        ]);
+
+        $holder = $this->makeHolder(record: $page);
+        $holder->fromSiteId = 7;
+
+        $this->assertNull($holder->fromSiteUrl());
+        $this->assertNull(
+            $holder->getBackToSiteAction(),
+            'Back-to-site action must not render when no SiteResource URL can be produced.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a multisite UX issue where editing a Page from a Site's relation manager (Sites → Site → Pages → Edit) drops the user into the global Pages resource with no breadcrumb back. After this PR they keep the site context and land back on the originating Site after save / delete.

- New `HasFromSiteContext` trait captures `?from_site=<id>` once at `mount()` into a Livewire public property — durable across `/livewire/update` round trips, so save / delete redirects don't lose context (which a `request()->query()` read inside lifecycle hooks would).
- `EditCmsPage` and `CreateCmsPage` consume the trait: subheading shows "Editing within site: <name>", "Back to site" header action renders when context is present, redirect after save / delete / force-delete lands on the Site edit URL instead of the global Pages index.
- `CmsPage::hasSiteIdColumn()` made `public` (was `protected`), `site()` belongsTo added (`TallCms\Cms\Models\Site` — cms-core class, no plugin dependency), and `'site_id' => 'integer'` cast added so loose Eloquent typing doesn't break `===` validation.
- Both `PagesRelationManager` files pass `from_site` (cms core copy + the multisite plugin runtime copy) — multisite doesn't disable cms-core's SiteResource, so depending on registration order either could be the path the user clicks through.

## Safety guarantees

- **Non-multisite installs**: trait's first guard checks `CmsPage::hasSiteIdColumn()`. When the multisite migration hasn't added the column, every entry point returns null and lifecycle hooks fall through to the parent class. Single-site behaviour is identical to before.
- **Spoofed `from_site` query**: the captured value is validated against the loaded record's `site_id` post-save, with a fallback to `$ownerSiteId` pre-save (so the back action renders on Create before Save). A `?from_site=99` link for a page belonging to site 7 falls through to default behaviour — no breadcrumb leak.
- **SiteResource URL resolution**: try/catch around `getUrl()` on the cms-core SiteResource and the multisite plugin's SiteResource in turn, with `class_exists()` guards. Hosts without either resource registered get null and the back action silently drops out — no `RouteNotFoundException` reaches the user.

## Architectural decisions (with prior reviewer feedback folded in)

- **Modal vs breadcrumb**: rejected modal because the CmsPage form is 453 lines, multi-tab (Content/SEO/Settings), with the block builder + RichEditor + 9 modal-form header actions. Modal-in-modal would be cramped and ESC-key ambiguous.
- **URL query param vs session**: query param survives page refresh and is easier to debug; session would pollute global Pages list state when the user navigates away.
- **Mount-time capture vs request-time read**: Livewire `/livewire/update` action requests have no access to the original page URL's query string. Reading `request()->query()` inside save/delete hooks would silently drop the value (the same lesson `CreateCmsPage::$ownerSiteId` already encodes).
- **Two query params on Create**: `?site=N` sets `site_id` explicitly on save (existing); `?from_site=N` drives navigation. Conceptually different even when numerically equal — keeps the pattern reusable for resources where ownership and navigation diverge.

## Test plan

- [x] `cd packages/tallcms/cms && vendor/bin/phpunit tests/Feature/Filament/CmsPageFromSiteContextTest.php` — 11 trait tests pass (single-site short-circuit, query capture, edit-path validation, create-path pre-save validation, spoof rejection, Eloquent string-vs-int safety, graceful URL fallback)
- [x] Full cms package suite green: 600 tests, 1189 assertions
- [x] CmsPage-related standalone tests green: 53 tests
- [ ] Manual smoke on push.test/admin: navigate Sites → site → Pages → Edit → confirm subheading + back action; save → confirm redirect to Site edit URL; delete → same; navigate to /admin/pages/{id}/edit directly → no subheading, no back action
- [ ] Multisite plugin release follow-up — runtime copy of `PagesRelationManager.php` is already updated in the monorepo working tree; the source-of-truth repo at `Herd/tallcms-multisite-plugin/` still needs the same patch + version bump per its RELEASING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)