### PR TITLE
Normalize block grid breakpoints + fix theme/A11y issues

### DIFF
--- a/packages/tallcms/cms/resources/views/cms/blocks/document-list.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/document-list.blade.php
@@ -54,7 +54,7 @@
         return $fileTypeConfig[$mimeType] ?? [
             'icon' => 'heroicon-o-document',
             'label' => strtoupper(Str::afterLast($mimeType, '/')),
-            'color' => 'text-gray-500'
+            'color' => 'text-base-content/60'
         ];
     };
 @endphp

--- a/packages/tallcms/cms/resources/views/cms/blocks/features.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/features.blade.php
@@ -1,9 +1,9 @@
 @php
     $columnsClass = match((string) ($columns ?? '3')) {
-        '2' => 'sm:grid-cols-2',
-        '3' => 'sm:grid-cols-2 lg:grid-cols-3',
-        '4' => 'sm:grid-cols-2 lg:grid-cols-4',
-        default => 'sm:grid-cols-2 lg:grid-cols-3',
+        '2' => 'grid-cols-1 sm:grid-cols-2',
+        '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+        '4' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',
+        default => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
     };
 
     $iconContainerClass = match($icon_size ?? 'w-10 h-10') {

--- a/packages/tallcms/cms/resources/views/cms/blocks/image-gallery.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/image-gallery.blade.php
@@ -303,6 +303,7 @@
             {{-- Close Button --}}
             <button
                 @click="close()"
+                aria-label="Close gallery"
                 class="btn btn-circle btn-ghost text-white absolute top-4 right-4"
             >
                 <x-heroicon-o-x-mark class="w-8 h-8" />
@@ -312,6 +313,7 @@
             <button
                 x-show="items.length > 1"
                 @click="prev()"
+                aria-label="Previous image"
                 class="btn btn-circle btn-ghost text-white absolute left-4 top-1/2 -translate-y-1/2"
             >
                 <x-heroicon-o-chevron-left class="w-8 h-8" />
@@ -321,6 +323,7 @@
             <button
                 x-show="items.length > 1"
                 @click="next()"
+                aria-label="Next image"
                 class="btn btn-circle btn-ghost text-white absolute right-4 top-1/2 -translate-y-1/2"
             >
                 <x-heroicon-o-chevron-right class="w-8 h-8" />

--- a/packages/tallcms/cms/resources/views/cms/blocks/logos.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/logos.blade.php
@@ -1,7 +1,7 @@
 @php
     $isGrid = ($layout ?? 'grid') === 'grid';
 
-    $columnsClass = match($columns ?? '5') {
+    $columnsClass = match((string) ($columns ?? '5')) {
         '2' => 'grid-cols-1 sm:grid-cols-2',
         '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
         '4' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',

--- a/packages/tallcms/cms/resources/views/cms/blocks/logos.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/logos.blade.php
@@ -4,10 +4,10 @@
     $columnsClass = match($columns ?? '5') {
         '2' => 'grid-cols-1 sm:grid-cols-2',
         '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
-        '4' => 'grid-cols-2 sm:grid-cols-4',
-        '5' => 'grid-cols-2 sm:grid-cols-3 lg:grid-cols-5',
-        '6' => 'grid-cols-2 sm:grid-cols-3 lg:grid-cols-6',
-        default => 'grid-cols-2 sm:grid-cols-3 lg:grid-cols-5',
+        '4' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',
+        '5' => 'grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5',
+        '6' => 'grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6',
+        default => 'grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5',
     };
 
     $sizeClasses = match($size ?? 'medium') {

--- a/packages/tallcms/cms/resources/views/cms/blocks/parallax.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/parallax.blade.php
@@ -80,7 +80,7 @@
                 @if(!empty($cta_text) && !empty($cta_url))
                     <a
                         href="{{ e($cta_url) }}"
-                        class="btn btn-neutral bg-white text-gray-900 hover:bg-gray-100 border-white gap-2"
+                        class="btn btn-primary gap-2"
                     >
                         {{ $cta_text }}
                         <x-heroicon-m-arrow-right class="w-5 h-5" />

--- a/packages/tallcms/cms/resources/views/cms/blocks/posts.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/posts.blade.php
@@ -208,9 +208,10 @@
 
     // Grid column classes
     $gridColumnClass = match($columns) {
-        '2' => 'sm:grid-cols-2',
-        '4' => 'sm:grid-cols-2 lg:grid-cols-4',
-        default => 'sm:grid-cols-2 lg:grid-cols-3'
+        '2' => 'grid-cols-1 sm:grid-cols-2',
+        '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+        '4' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',
+        default => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'
     };
 
     // Helper to generate post URL (uses localized URL helper)

--- a/packages/tallcms/cms/resources/views/cms/blocks/posts.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/posts.blade.php
@@ -207,7 +207,7 @@
     $staggerDelay = (int) ($animation_stagger_delay ?? 100);
 
     // Grid column classes
-    $gridColumnClass = match($columns) {
+    $gridColumnClass = match((string) ($columns ?? '3')) {
         '2' => 'grid-cols-1 sm:grid-cols-2',
         '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
         '4' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',

--- a/packages/tallcms/cms/resources/views/cms/blocks/pricing.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/pricing.blade.php
@@ -11,10 +11,10 @@
     // Grid classes based on columns
     $gridClasses = match($columns) {
         '1' => 'grid-cols-1',
-        '2' => 'grid-cols-1 md:grid-cols-2',
-        '3' => 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
-        '4' => 'grid-cols-1 md:grid-cols-2 lg:grid-cols-4',
-        default => 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'
+        '2' => 'grid-cols-1 sm:grid-cols-2',
+        '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+        '4' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',
+        default => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'
     };
 
     // Spacing classes

--- a/packages/tallcms/cms/resources/views/cms/blocks/pricing.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/pricing.blade.php
@@ -9,7 +9,7 @@
     $sectionPadding = ($first_section ?? false) ? 'pb-16' : ($padding ?? 'py-16');
 
     // Grid classes based on columns
-    $gridClasses = match($columns) {
+    $gridClasses = match((string) ($columns ?? '3')) {
         '1' => 'grid-cols-1',
         '2' => 'grid-cols-1 sm:grid-cols-2',
         '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',

--- a/packages/tallcms/cms/resources/views/cms/blocks/stats.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/stats.blade.php
@@ -1,5 +1,5 @@
 @php
-    $columnsClass = match($columns ?? '4') {
+    $columnsClass = match((string) ($columns ?? '4')) {
         '2' => 'grid-cols-1 sm:grid-cols-2 max-w-3xl mx-auto',
         '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto',
         '4' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',
@@ -77,9 +77,10 @@
             </x-tallcms::animation-wrapper>
         @endif
 
-        {{-- Stats Grid using daisyUI stats component --}}
+        {{-- Stats Grid: plain Tailwind grid so $columnsClass actually controls column count.
+             daisyUI's .stats component uses grid-auto-flow:column which ignores grid-cols-N. --}}
         @if(!empty($stats))
-            <div class="stats stats-vertical lg:stats-horizontal shadow w-full {{ $columnsClass }} grid">
+            <div class="grid {{ $columnsClass }} gap-px bg-base-200 rounded-box shadow overflow-hidden w-full">
                 @foreach($stats as $index => $stat)
                     @php
                         $itemDelay = $animationStagger ? ($staggerDelay * ($index + 1)) : 0;
@@ -89,7 +90,7 @@
                         :duration="$animationDuration"
                         :use-parent="true"
                         :delay="$itemDelay"
-                        class="{{ $stat_style ?? 'stat' }} {{ $text_alignment ?? 'text-center' }} place-items-center"
+                        class="{{ $stat_style ?? 'stat' }} bg-base-100 {{ $text_alignment ?? 'text-center' }} place-items-center"
                     >
                         {{-- Icon --}}
                         @if(!empty($stat['icon']))

--- a/packages/tallcms/cms/resources/views/cms/blocks/stats.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/stats.blade.php
@@ -1,9 +1,9 @@
 @php
     $columnsClass = match($columns ?? '4') {
-        '2' => 'sm:grid-cols-2 max-w-3xl mx-auto',
-        '3' => 'sm:grid-cols-3 max-w-5xl mx-auto',
-        '4' => 'sm:grid-cols-2 lg:grid-cols-4',
-        default => 'sm:grid-cols-2 lg:grid-cols-4',
+        '2' => 'grid-cols-1 sm:grid-cols-2 max-w-3xl mx-auto',
+        '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto',
+        '4' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',
+        default => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',
     };
 
     $sectionPadding = ($first_section ?? false) ? 'pb-16' : ($padding ?? 'py-16');

--- a/packages/tallcms/cms/resources/views/cms/blocks/team.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/team.blade.php
@@ -1,9 +1,9 @@
 @php
     $columnsClass = match((string) ($columns ?? '3')) {
-        '2' => 'sm:grid-cols-2 max-w-4xl mx-auto',
-        '3' => 'sm:grid-cols-2 lg:grid-cols-3',
-        '4' => 'sm:grid-cols-2 md:grid-cols-4',
-        default => 'sm:grid-cols-2 lg:grid-cols-3',
+        '2' => 'grid-cols-1 sm:grid-cols-2 max-w-4xl mx-auto',
+        '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+        '4' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',
+        default => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
     };
 
     $sectionPadding = ($first_section ?? false) ? 'pb-16' : ($padding ?? 'py-16');

--- a/packages/tallcms/cms/resources/views/cms/blocks/testimonials.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/testimonials.blade.php
@@ -1,5 +1,5 @@
 @php
-    $columnsClass = match($columns ?? '3') {
+    $columnsClass = match((string) ($columns ?? '3')) {
         '1' => 'grid-cols-1 max-w-2xl mx-auto',
         '2' => 'grid-cols-1 sm:grid-cols-2 max-w-4xl mx-auto',
         '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',

--- a/packages/tallcms/cms/resources/views/cms/blocks/testimonials.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/testimonials.blade.php
@@ -1,9 +1,9 @@
 @php
     $columnsClass = match($columns ?? '3') {
-        '1' => 'max-w-2xl mx-auto',
-        '2' => 'sm:grid-cols-2 max-w-4xl mx-auto',
-        '3' => 'sm:grid-cols-2 lg:grid-cols-3',
-        default => 'sm:grid-cols-2 lg:grid-cols-3',
+        '1' => 'grid-cols-1 max-w-2xl mx-auto',
+        '2' => 'grid-cols-1 sm:grid-cols-2 max-w-4xl mx-auto',
+        '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+        default => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
     };
 
     $styleClasses = $card_style ?? 'card bg-base-200 shadow-lg';

--- a/resources/views/cms/blocks/features.blade.php
+++ b/resources/views/cms/blocks/features.blade.php
@@ -1,5 +1,5 @@
 @php
-    $columnsClass = match($columns ?? '3') {
+    $columnsClass = match((string) ($columns ?? '3')) {
         '2' => 'grid-cols-1 sm:grid-cols-2',
         '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
         '4' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',

--- a/resources/views/cms/blocks/features.blade.php
+++ b/resources/views/cms/blocks/features.blade.php
@@ -1,9 +1,9 @@
 @php
     $columnsClass = match($columns ?? '3') {
-        '2' => 'sm:grid-cols-2',
-        '3' => 'sm:grid-cols-2 lg:grid-cols-3',
-        '4' => 'sm:grid-cols-2 lg:grid-cols-4',
-        default => 'sm:grid-cols-2 lg:grid-cols-3',
+        '2' => 'grid-cols-1 sm:grid-cols-2',
+        '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+        '4' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',
+        default => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
     };
 
     $iconContainerClass = match($icon_size ?? 'w-10 h-10') {

--- a/resources/views/cms/blocks/image-gallery.blade.php
+++ b/resources/views/cms/blocks/image-gallery.blade.php
@@ -122,6 +122,7 @@
             {{-- Close Button --}}
             <button
                 @click="close()"
+                aria-label="Close gallery"
                 class="btn btn-circle btn-ghost text-white absolute top-4 right-4"
             >
                 <x-heroicon-o-x-mark class="w-8 h-8" />
@@ -130,6 +131,7 @@
             {{-- Previous Button --}}
             <button
                 @click="prev()"
+                aria-label="Previous image"
                 class="btn btn-circle btn-ghost text-white absolute left-4 top-1/2 -translate-y-1/2"
             >
                 <x-heroicon-o-chevron-left class="w-8 h-8" />
@@ -138,6 +140,7 @@
             {{-- Next Button --}}
             <button
                 @click="next()"
+                aria-label="Next image"
                 class="btn btn-circle btn-ghost text-white absolute right-4 top-1/2 -translate-y-1/2"
             >
                 <x-heroicon-o-chevron-right class="w-8 h-8" />

--- a/resources/views/cms/blocks/posts.blade.php
+++ b/resources/views/cms/blocks/posts.blade.php
@@ -110,7 +110,7 @@
     $sectionPadding = $firstSection ? 'pb-16' : $sectionPaddingClass;
 
     // Grid column classes
-    $gridColumnClass = match($columns) {
+    $gridColumnClass = match((string) ($columns ?? '3')) {
         '2' => 'grid-cols-1 sm:grid-cols-2',
         '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
         '4' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',

--- a/resources/views/cms/blocks/posts.blade.php
+++ b/resources/views/cms/blocks/posts.blade.php
@@ -111,9 +111,10 @@
 
     // Grid column classes
     $gridColumnClass = match($columns) {
-        '2' => 'sm:grid-cols-2',
-        '4' => 'sm:grid-cols-2 lg:grid-cols-4',
-        default => 'sm:grid-cols-2 lg:grid-cols-3'
+        '2' => 'grid-cols-1 sm:grid-cols-2',
+        '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+        '4' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',
+        default => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'
     };
 
     // Helper to generate post URL

--- a/resources/views/cms/blocks/pricing.blade.php
+++ b/resources/views/cms/blocks/pricing.blade.php
@@ -11,10 +11,10 @@
     // Grid classes based on columns
     $gridClasses = match($columns) {
         '1' => 'grid-cols-1',
-        '2' => 'grid-cols-1 md:grid-cols-2',
-        '3' => 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
-        '4' => 'grid-cols-1 md:grid-cols-2 lg:grid-cols-4',
-        default => 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'
+        '2' => 'grid-cols-1 sm:grid-cols-2',
+        '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+        '4' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',
+        default => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'
     };
 
     // Spacing classes

--- a/resources/views/cms/blocks/pricing.blade.php
+++ b/resources/views/cms/blocks/pricing.blade.php
@@ -9,7 +9,7 @@
     $sectionPadding = ($first_section ?? false) ? 'pb-16' : ($padding ?? 'py-16');
 
     // Grid classes based on columns
-    $gridClasses = match($columns) {
+    $gridClasses = match((string) ($columns ?? '3')) {
         '1' => 'grid-cols-1',
         '2' => 'grid-cols-1 sm:grid-cols-2',
         '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',

--- a/resources/views/cms/blocks/team.blade.php
+++ b/resources/views/cms/blocks/team.blade.php
@@ -1,9 +1,9 @@
 @php
     $columnsClass = match((string) ($columns ?? '3')) {
-        '2' => 'sm:grid-cols-2 max-w-4xl mx-auto',
-        '3' => 'sm:grid-cols-2 lg:grid-cols-3',
-        '4' => 'sm:grid-cols-2 md:grid-cols-4',
-        default => 'sm:grid-cols-2 lg:grid-cols-3',
+        '2' => 'grid-cols-1 sm:grid-cols-2 max-w-4xl mx-auto',
+        '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+        '4' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',
+        default => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
     };
 
     $sectionPadding = ($first_section ?? false) ? 'pb-16' : ($padding ?? 'py-16');

--- a/resources/views/cms/blocks/testimonials.blade.php
+++ b/resources/views/cms/blocks/testimonials.blade.php
@@ -1,5 +1,5 @@
 @php
-    $columnsClass = match($columns ?? '3') {
+    $columnsClass = match((string) ($columns ?? '3')) {
         '1' => 'grid-cols-1 max-w-2xl mx-auto',
         '2' => 'grid-cols-1 sm:grid-cols-2 max-w-4xl mx-auto',
         '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',

--- a/resources/views/cms/blocks/testimonials.blade.php
+++ b/resources/views/cms/blocks/testimonials.blade.php
@@ -1,9 +1,9 @@
 @php
     $columnsClass = match($columns ?? '3') {
-        '1' => 'max-w-2xl mx-auto',
-        '2' => 'sm:grid-cols-2 max-w-4xl mx-auto',
-        '3' => 'sm:grid-cols-2 lg:grid-cols-3',
-        default => 'sm:grid-cols-2 lg:grid-cols-3',
+        '1' => 'grid-cols-1 max-w-2xl mx-auto',
+        '2' => 'grid-cols-1 sm:grid-cols-2 max-w-4xl mx-auto',
+        '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+        default => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
     };
 
     $styleClasses = $card_style ?? 'card bg-base-200 shadow-lg';


### PR DESCRIPTION
## Summary

- **Grid normalization** across 7 grid-capable blocks (Features, Team, Testimonials, Posts, Pricing, Stats, Logos). Every block now uses the same `mobile 1 → sm 2 → lg N` ladder. Fixes Logos' reversed 4/5/6 ramps, adds the missing `'3'` arm to Posts, brings Team's `'4'` in line with siblings, and moves Pricing from `md:` to `sm:` so card-heavy blocks behave consistently at every breakpoint. Applied symmetrically to the 5 standalone overrides that shadow these views.
- **Theme-token fix**: Parallax CTA button no longer hardcodes `bg-white/text-gray-900` (invisible in dark themes) — now uses `btn-primary`.
- **Theme-token fix**: Document List icon fallback color moved from hardcoded `text-gray-500` to `text-base-content/60` so it respects the active daisyUI theme.
- **A11y**: Image Gallery lightbox close/prev/next icon-only buttons gained `aria-label`s in both the package and standalone copies.

## Context

Production use surfaced inconsistent column rendering across grid blocks — picking "4 columns" produced visibly different tablet behavior depending on which block you used. The chosen ramp (`mobile 1 → sm 2 → lg N`) is intentionally conservative on tablets so card-heavy blocks stay readable; the win is consistency across blocks, not denser tablets. 

## Files changed

- 7 package grid views + 5 standalone grid overrides = 12 files for grid normalization
- 3 package theme/A11y fixes (Parallax, Document List, Image Gallery) + 1 standalone Image Gallery A11y fix = 4 files

Total: 16 files. No PHP schema, config, or asset-build changes.

## Test plan

- [x] `npm run build` — clean.
- [x] Block-related phpunit (95 tests) — all pass, including `ImageGalleryBlockGridLayoutTest`.
- [x] Package phpunit (600 tests) — all pass.
- [x] Manual visual check in admin block editor — drop in Features/Team/Testimonials/Posts/Pricing/Stats/Logos with each `columns` setting, resize through mobile (<640) → sm (640+) → md (768+) → lg (1024+) and verify the consistency property:
  - **mobile (<640)**: 1 column for every block.
  - **sm (640–767)**: 1 col when `columns=1` (Testimonials/Pricing); otherwise 2 cols. Logos at 5/6 shows 2.
  - **md (768–1023)**: 1 col when `columns=1`; otherwise 2 cols for card-heavy blocks regardless of selection. Logos at 5/6 shows 3.
  - **lg (≥1024)**: editor's selected column count.
- [x] Theme check — switch to dark daisyUI theme, drop a Parallax block with light overlay, confirm CTA button is readable. Also Document List with an unrecognized MIME type (e.g. `.epub`).
- [x] A11y spot check — open Image Gallery lightbox, tab through buttons or run axe DevTools, confirm "Close gallery" / "Previous image" / "Next image" labels are exposed.

## Out of scope (deferred)

- Image alt text + lazy loading polish on Timeline/Posts/Gallery
- Schema UX: missing `helperText()` on layout fields, button-naming consistency, image+alt trait, repeater translation
- Hero/Pricing/Testimonials minor design polish

These are documented in the local audit and can be tackled as a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)