### PR TITLE
Per-site toggles for theme switcher / search / language dropdown

### DIFF
--- a/packages/tallcms/cms/resources/themes/elevate/resources/views/layouts/app.blade.php
+++ b/packages/tallcms/cms/resources/themes/elevate/resources/views/layouts/app.blade.php
@@ -110,7 +110,7 @@
                 </div>
 
                 <div class="navbar-end">
-                    @if(supports_theme_controller())
+                    @if(tallcms_show_theme_switcher())
                         <div class="dropdown dropdown-end">
                             <div tabindex="0" role="button" class="btn btn-ghost btn-sm btn-circle">
                                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/packages/tallcms/cms/resources/themes/talldaisy/resources/views/layouts/app.blade.php
+++ b/packages/tallcms/cms/resources/themes/talldaisy/resources/views/layouts/app.blade.php
@@ -139,13 +139,17 @@
 
                     <div class="navbar-end gap-2">
                         <!-- Search -->
-                        @include('theme.talldaisy::components.header-search')
+                        @if(tallcms_show_search())
+                            @include('theme.talldaisy::components.header-search')
+                        @endif
 
                         <!-- Language Switcher -->
-                        @include('theme.talldaisy::components.language-switcher')
+                        @if(tallcms_show_language_dropdown())
+                            @include('theme.talldaisy::components.language-switcher')
+                        @endif
 
                         <!-- Theme Switcher -->
-                        @if(supports_theme_controller())
+                        @if(tallcms_show_theme_switcher())
                             @include('theme.talldaisy::components.theme-switcher')
                         @endif
                     </div>

--- a/packages/tallcms/cms/resources/themes/talldaisy/theme.json
+++ b/packages/tallcms/cms/resources/themes/talldaisy/theme.json
@@ -13,6 +13,8 @@
     "supports": {
         "dark_mode": true,
         "theme_controller": true,
+        "search": true,
+        "language_switcher": true,
         "responsive": true,
         "animations": true
     },

--- a/packages/tallcms/cms/resources/views/filament/pages/theme-manager.blade.php
+++ b/packages/tallcms/cms/resources/views/filament/pages/theme-manager.blade.php
@@ -947,6 +947,51 @@
                     </div>
                 @endif
 
+                {{-- Display Options (active theme only) --}}
+                @php
+                    $hasSearchSupport = (bool) ($themeDetails['supports']['search'] ?? false);
+                    $hasLangSupport = (bool) ($themeDetails['supports']['language_switcher'] ?? false);
+                    $hasAnyDisplayOption = $themeDetails['hasThemeController'] || $hasSearchSupport || $hasLangSupport;
+                @endphp
+                @if($themeDetails['isActive'] && $hasAnyDisplayOption)
+                    <div class="bg-gray-50 dark:bg-white/5 rounded-lg p-3">
+                        <h4 class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">Display Options</h4>
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">Show or hide controls in the site header. Saved automatically.</p>
+                        <div class="space-y-2">
+                            @if($themeDetails['hasThemeController'])
+                                <label class="flex items-center justify-between gap-3 cursor-pointer">
+                                    <span class="text-sm text-gray-700 dark:text-gray-300">Theme switcher</span>
+                                    <input
+                                        type="checkbox"
+                                        class="toggle toggle-sm toggle-primary"
+                                        wire:model.live="showThemeSwitcher"
+                                    />
+                                </label>
+                            @endif
+                            @if($hasSearchSupport)
+                                <label class="flex items-center justify-between gap-3 cursor-pointer">
+                                    <span class="text-sm text-gray-700 dark:text-gray-300">Search box</span>
+                                    <input
+                                        type="checkbox"
+                                        class="toggle toggle-sm toggle-primary"
+                                        wire:model.live="showSearch"
+                                    />
+                                </label>
+                            @endif
+                            @if($hasLangSupport)
+                                <label class="flex items-center justify-between gap-3 cursor-pointer">
+                                    <span class="text-sm text-gray-700 dark:text-gray-300">Language dropdown</span>
+                                    <input
+                                        type="checkbox"
+                                        class="toggle toggle-sm toggle-primary"
+                                        wire:model.live="showLanguageDropdown"
+                                    />
+                                </label>
+                            @endif
+                        </div>
+                    </div>
+                @endif
+
                 {{-- Features Grid --}}
                 @if(!empty($themeDetails['supports']))
                     <div class="bg-gray-50 dark:bg-white/5 rounded-lg p-3">

--- a/packages/tallcms/cms/resources/views/filament/pages/theme-manager.blade.php
+++ b/packages/tallcms/cms/resources/views/filament/pages/theme-manager.blade.php
@@ -338,17 +338,18 @@
                                 || ($theme['supports']['search'] ?? false)
                                 || ($theme['supports']['language_switcher'] ?? false);
                         @endphp
-                        <div class="absolute top-2 right-2 flex flex-col items-end gap-1">
-                            <x-filament::badge color="success" size="sm">
+                        <div class="absolute top-2 right-2">
+                            <x-filament::badge
+                                color="success"
+                                size="sm"
+                                :tooltip="$hasConfigurableDisplayOptions ? 'Open Details to toggle header controls' : null"
+                            >
                                 <x-heroicon-s-check-circle class="w-3 h-3 mr-0.5" />
                                 Active
+                                @if($hasConfigurableDisplayOptions)
+                                    <x-heroicon-m-adjustments-horizontal class="w-3 h-3 ml-1 opacity-80" />
+                                @endif
                             </x-filament::badge>
-                            @if($hasConfigurableDisplayOptions)
-                                <x-filament::badge color="info" size="sm" title="Open Details to toggle header controls">
-                                    <x-heroicon-s-adjustments-horizontal class="w-3 h-3 mr-0.5" />
-                                    Configurable
-                                </x-filament::badge>
-                            @endif
                         </div>
                     @endif
 

--- a/packages/tallcms/cms/resources/views/filament/pages/theme-manager.blade.php
+++ b/packages/tallcms/cms/resources/views/filament/pages/theme-manager.blade.php
@@ -333,11 +333,22 @@
 
                     {{-- Active Badge --}}
                     @if($theme['isActive'])
-                        <div class="absolute top-2 right-2">
+                        @php
+                            $hasConfigurableDisplayOptions = $theme['hasThemeController']
+                                || ($theme['supports']['search'] ?? false)
+                                || ($theme['supports']['language_switcher'] ?? false);
+                        @endphp
+                        <div class="absolute top-2 right-2 flex flex-col items-end gap-1">
                             <x-filament::badge color="success" size="sm">
                                 <x-heroicon-s-check-circle class="w-3 h-3 mr-0.5" />
                                 Active
                             </x-filament::badge>
+                            @if($hasConfigurableDisplayOptions)
+                                <x-filament::badge color="info" size="sm" title="Open Details to toggle header controls">
+                                    <x-heroicon-s-adjustments-horizontal class="w-3 h-3 mr-0.5" />
+                                    Configurable
+                                </x-filament::badge>
+                            @endif
                         </div>
                     @endif
 

--- a/packages/tallcms/cms/src/Console/Commands/MakeTheme.php
+++ b/packages/tallcms/cms/src/Console/Commands/MakeTheme.php
@@ -840,10 +840,14 @@ BLADE;
     {
         return <<<'BLADE'
 {{-- Minimal language dropdown. Visibility (theme support + i18n_enabled + admin toggle)
-     is enforced by tallcms_show_language_dropdown() before this partial is included. --}}
+     is enforced by tallcms_show_language_dropdown() before this partial is included.
+     Uses tallcms_current_slug() to strip the existing locale/route prefixes from the
+     request path so tallcms_localized_url() builds a clean URL for the target locale. --}}
 @php
-    $locales = collect(config('tallcms.i18n.locales', []))->keys()->all();
+    $registry = app(\TallCms\Cms\Services\LocaleRegistry::class);
     $current = app()->getLocale();
+    $locales = $registry->getLocales();
+    $cleanSlug = tallcms_current_slug();
 @endphp
 
 @if(count($locales) >= 2)
@@ -857,10 +861,12 @@ BLADE;
             <span class="uppercase text-xs">{{ $current }}</span>
         </div>
         <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-50 w-40 p-2 shadow">
-            @foreach($locales as $locale)
+            @foreach($locales as $code => $locale)
                 <li>
-                    <a href="{{ tallcms_localized_url(request()->path(), $locale) }}" @if($locale === $current) class="active" @endif>
-                        {{ strtoupper($locale) }}
+                    <a href="{{ url(tallcms_localized_url($cleanSlug, $code)) }}"
+                       hreflang="{{ \TallCms\Cms\Services\LocaleRegistry::toBcp47($code) }}"
+                       @if($code === $current) class="active" aria-current="true" @endif>
+                        {{ $locale['native'] ?? strtoupper($code) }}
                     </a>
                 </li>
             @endforeach

--- a/packages/tallcms/cms/src/Console/Commands/MakeTheme.php
+++ b/packages/tallcms/cms/src/Console/Commands/MakeTheme.php
@@ -17,6 +17,8 @@ class MakeTheme extends Command
                             {--author= : Theme author name}
                             {--description= : Theme description}
                             {--theme-version= : Theme version}
+                            {--include-search : Scaffold a header search box component}
+                            {--include-language-switcher : Scaffold a language dropdown component}
                             {--interactive : Force interactive mode even with arguments}';
 
     protected $description = 'Create a new TallCMS theme with daisyUI integration';
@@ -174,6 +176,12 @@ class MakeTheme extends Command
             $prefersDark = 'dark';
         }
 
+        // Optional header controls — drives supports.* in theme.json and component scaffolding.
+        $this->newLine();
+        $this->line('Header controls (declare which optional UI controls this theme renders):');
+        $includeSearch = $this->confirm('Include a search box in the header?', false);
+        $includeLanguageSwitcher = $this->confirm('Include a language dropdown in the header?', false);
+
         return [
             'name' => $name,
             'slug' => Str::slug($name),
@@ -185,6 +193,8 @@ class MakeTheme extends Command
             'prefersDark' => $prefersDark,
             'allPresets' => $allPresets,
             'customColors' => $customColors,
+            'includeSearch' => $includeSearch,
+            'includeLanguageSwitcher' => $includeLanguageSwitcher,
         ];
     }
 
@@ -237,6 +247,8 @@ class MakeTheme extends Command
             'prefersDark' => $prefersDark,
             'allPresets' => $allPresets,
             'customColors' => $customColors,
+            'includeSearch' => (bool) $this->option('include-search'),
+            'includeLanguageSwitcher' => (bool) $this->option('include-language-switcher'),
         ];
     }
 
@@ -297,6 +309,8 @@ class MakeTheme extends Command
             $config['supports'] = [
                 'dark_mode' => false,
                 'theme_controller' => false,
+                'search' => (bool) ($themeInfo['includeSearch'] ?? false),
+                'language_switcher' => (bool) ($themeInfo['includeLanguageSwitcher'] ?? false),
                 'responsive' => true,
                 'animations' => true,
             ];
@@ -319,6 +333,8 @@ class MakeTheme extends Command
             $config['supports'] = [
                 'dark_mode' => $themeInfo['prefersDark'] !== null,
                 'theme_controller' => $themeInfo['allPresets'],
+                'search' => (bool) ($themeInfo['includeSearch'] ?? false),
+                'language_switcher' => (bool) ($themeInfo['includeLanguageSwitcher'] ?? false),
                 'responsive' => true,
                 'animations' => true,
             ];
@@ -551,6 +567,20 @@ JS;
             $this->line('Created: resources/views/components/theme-switcher.blade.php');
         }
 
+        // Optional: search component
+        if (! empty($themeInfo['includeSearch'])) {
+            $search = $this->getHeaderSearchTemplate();
+            File::put("{$themePath}/resources/views/components/header-search.blade.php", $search);
+            $this->line('Created: resources/views/components/header-search.blade.php');
+        }
+
+        // Optional: language switcher component
+        if (! empty($themeInfo['includeLanguageSwitcher'])) {
+            $langSwitcher = $this->getLanguageSwitcherTemplate();
+            File::put("{$themePath}/resources/views/components/language-switcher.blade.php", $langSwitcher);
+            $this->line('Created: resources/views/components/language-switcher.blade.php');
+        }
+
         // Create example template
         $exampleTemplate = $this->getExampleTemplateContent();
         File::put("{$themePath}/resources/views/templates/example.blade.php", $exampleTemplate);
@@ -601,9 +631,24 @@ GITIGNORE;
 
     protected function getLayoutTemplate(string $studlyName, array $themeInfo): string
     {
-        $themeSwitcher = $themeInfo['allPresets']
-            ? "@if(supports_theme_controller())\n                @include('theme.{$themeInfo['slug']}::components.theme-switcher')\n            @endif"
-            : '{{-- Theme switcher: enable "all presets" mode to add theme-controller --}}';
+        $slug = $themeInfo['slug'];
+        $navbarEndParts = [];
+
+        if (! empty($themeInfo['includeSearch'])) {
+            $navbarEndParts[] = "                <!-- Search -->\n                @if(tallcms_show_search())\n                    @include('theme.{$slug}::components.header-search')\n                @endif";
+        }
+
+        if (! empty($themeInfo['includeLanguageSwitcher'])) {
+            $navbarEndParts[] = "                <!-- Language Switcher -->\n                @if(tallcms_show_language_dropdown())\n                    @include('theme.{$slug}::components.language-switcher')\n                @endif";
+        }
+
+        if ($themeInfo['allPresets']) {
+            $navbarEndParts[] = "                <!-- Theme Switcher -->\n                @if(tallcms_show_theme_switcher())\n                    @include('theme.{$slug}::components.theme-switcher')\n                @endif";
+        } else {
+            $navbarEndParts[] = '                {{-- Theme switcher: enable "all presets" mode to add theme-controller --}}';
+        }
+
+        $themeSwitcher = ltrim(implode("\n\n", $navbarEndParts));
 
         return <<<BLADE
 <!DOCTYPE html>
@@ -697,8 +742,7 @@ GITIGNORE;
             </div>
 
             <div class="navbar-end gap-2">
-                <!-- Theme Switcher -->
-                {$themeSwitcher}
+{$themeSwitcher}
             </div>
         </div>
     @endif
@@ -765,6 +809,64 @@ BLADE;
         @endforeach
     </ul>
 </div>
+BLADE;
+    }
+
+    protected function getHeaderSearchTemplate(): string
+    {
+        return <<<'BLADE'
+{{-- Minimal header search component. The visibility gate
+     (theme support + admin toggle + global config) lives in tallcms_show_search();
+     this partial only renders the input. --}}
+<form action="{{ tallcms_search_url() }}" method="get" class="form-control">
+    <label class="input input-sm input-bordered flex items-center gap-2">
+        <svg class="w-4 h-4 opacity-60" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M21 21l-4.35-4.35M16.65 16.65A7.5 7.5 0 105.25 5.25a7.5 7.5 0 0011.4 11.4z"/>
+        </svg>
+        <input
+            type="search"
+            name="q"
+            value="{{ request('q') }}"
+            placeholder="{{ __('Search') }}"
+            class="grow"
+        />
+    </label>
+</form>
+BLADE;
+    }
+
+    protected function getLanguageSwitcherTemplate(): string
+    {
+        return <<<'BLADE'
+{{-- Minimal language dropdown. Visibility (theme support + i18n_enabled + admin toggle)
+     is enforced by tallcms_show_language_dropdown() before this partial is included. --}}
+@php
+    $locales = collect(config('tallcms.i18n.locales', []))->keys()->all();
+    $current = app()->getLocale();
+@endphp
+
+@if(count($locales) >= 2)
+    <div class="dropdown dropdown-end">
+        <div tabindex="0" role="button" class="btn btn-ghost btn-sm gap-1" aria-label="{{ __('Change language') }}">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                      d="M3.6 9h16.8M3.6 15h16.8M11.5 3a16 16 0 010 18M12.5 3a16 16 0 010 18"/>
+                <circle cx="12" cy="12" r="9" stroke-width="2"/>
+            </svg>
+            <span class="uppercase text-xs">{{ $current }}</span>
+        </div>
+        <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-50 w-40 p-2 shadow">
+            @foreach($locales as $locale)
+                <li>
+                    <a href="{{ tallcms_localized_url(request()->path(), $locale) }}" @if($locale === $current) class="active" @endif>
+                        {{ strtoupper($locale) }}
+                    </a>
+                </li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 BLADE;
     }
 }

--- a/packages/tallcms/cms/src/Filament/Pages/GlobalDefaults.php
+++ b/packages/tallcms/cms/src/Filament/Pages/GlobalDefaults.php
@@ -96,6 +96,9 @@ class GlobalDefaults extends Page implements HasForms
         'logo' => 'file',
         'favicon' => 'file',
         'show_powered_by' => 'boolean',
+        'show_theme_switcher' => 'boolean',
+        'show_search' => 'boolean',
+        'show_language_dropdown' => 'boolean',
         // Publishing
         'review_workflow_enabled' => 'boolean',
         // Maintenance
@@ -109,7 +112,10 @@ class GlobalDefaults extends Page implements HasForms
 
         foreach ($this->settingKeys as $key => $type) {
             $default = match ($key) {
-                'show_powered_by' => true,
+                'show_powered_by',
+                'show_theme_switcher',
+                'show_search',
+                'show_language_dropdown' => true,
                 'site_type' => 'multi-page',
                 'maintenance_message' => "We're currently performing scheduled maintenance. Please check back soon!",
                 default => null,
@@ -152,7 +158,8 @@ class GlobalDefaults extends Page implements HasForms
                 'contact_email', 'contact_phone', 'company_name', 'company_address' => 'contact',
                 'social_facebook', 'social_twitter', 'social_linkedin', 'social_instagram',
                 'social_youtube', 'social_tiktok', 'newsletter_signup_url' => 'social',
-                'logo', 'favicon', 'show_powered_by' => 'branding',
+                'logo', 'favicon', 'show_powered_by',
+                'show_theme_switcher', 'show_search', 'show_language_dropdown' => 'branding',
                 'review_workflow_enabled' => 'publishing',
                 'maintenance_mode', 'maintenance_message' => 'maintenance',
                 default => 'general',
@@ -280,6 +287,24 @@ class GlobalDefaults extends Page implements HasForms
                         Toggle::make('show_powered_by')
                             ->label('Show "Powered by TallCMS" Badge')
                             ->helperText('Displays a small badge in the site footer.')
+                            ->default(true)
+                            ->columnSpanFull(),
+
+                        Toggle::make('show_theme_switcher')
+                            ->label('Show theme switcher in header')
+                            ->helperText('Default for sites whose theme supports runtime theme switching. Per-site overrides win.')
+                            ->default(true)
+                            ->columnSpanFull(),
+
+                        Toggle::make('show_search')
+                            ->label('Show search box in header')
+                            ->helperText('Default for sites whose theme renders a search control. Per-site overrides win.')
+                            ->default(true)
+                            ->columnSpanFull(),
+
+                        Toggle::make('show_language_dropdown')
+                            ->label('Show language dropdown in header')
+                            ->helperText('Default for sites whose theme renders a locale switcher. Only effective when i18n is enabled.')
                             ->default(true)
                             ->columnSpanFull(),
                     ])

--- a/packages/tallcms/cms/src/Filament/Pages/ThemeManager.php
+++ b/packages/tallcms/cms/src/Filament/Pages/ThemeManager.php
@@ -78,9 +78,37 @@ class ThemeManager extends Page implements HasForms
 
     public array $licenseStatuses = [];
 
+    /**
+     * Display Options toggles, hydrated only when the slide-over is opened
+     * for the *active* theme. See showThemeDetails() and the updated* hooks below.
+     */
+    public bool $showThemeSwitcher = true;
+
+    public bool $showSearch = true;
+
+    public bool $showLanguageDropdown = true;
+
     public function mount(): void
     {
         $this->refreshLicenseStatuses();
+    }
+
+    public function updatedShowThemeSwitcher(bool $value): void
+    {
+        SiteSetting::set('show_theme_switcher', $value, 'boolean', 'branding');
+        SiteSetting::clearCache();
+    }
+
+    public function updatedShowSearch(bool $value): void
+    {
+        SiteSetting::set('show_search', $value, 'boolean', 'branding');
+        SiteSetting::clearCache();
+    }
+
+    public function updatedShowLanguageDropdown(bool $value): void
+    {
+        SiteSetting::set('show_language_dropdown', $value, 'boolean', 'branding');
+        SiteSetting::clearCache();
     }
 
     /**
@@ -755,6 +783,15 @@ class ThemeManager extends Page implements HasForms
             'hasAnimations' => $theme->supports('animations'),
             'purchaseUrl' => $theme->getPurchaseUrl(),
         ];
+
+        // Hydrate Display Options toggles only for the active theme — they edit
+        // site-wide SiteSetting values and would be misleading when shown for
+        // an inactive theme. The Blade also gates on isActive for the same reason.
+        if ($activeSlug === $theme->slug) {
+            $this->showThemeSwitcher = (bool) SiteSetting::get('show_theme_switcher', true);
+            $this->showSearch = (bool) SiteSetting::get('show_search', true);
+            $this->showLanguageDropdown = (bool) SiteSetting::get('show_language_dropdown', true);
+        }
 
         $this->dispatch('open-modal', id: 'theme-details-modal');
     }

--- a/packages/tallcms/cms/src/Filament/Resources/SiteResource/Pages/EditSite.php
+++ b/packages/tallcms/cms/src/Filament/Resources/SiteResource/Pages/EditSite.php
@@ -61,6 +61,9 @@ class EditSite extends Page implements HasForms
         'logo' => 'file',
         'favicon' => 'file',
         'show_powered_by' => 'boolean',
+        'show_theme_switcher' => 'boolean',
+        'show_search' => 'boolean',
+        'show_language_dropdown' => 'boolean',
         // Publishing
         'review_workflow_enabled' => 'boolean',
         // Maintenance
@@ -89,7 +92,10 @@ class EditSite extends Page implements HasForms
         // Load all 20 settings from SiteSettingsService
         foreach ($this->settingKeys as $key => $type) {
             $default = match ($key) {
-                'show_powered_by' => true,
+                'show_powered_by',
+                'show_theme_switcher',
+                'show_search',
+                'show_language_dropdown' => true,
                 'site_type' => 'multi-page',
                 'maintenance_message' => "We're currently performing scheduled maintenance. Please check back soon!",
                 default => null,

--- a/packages/tallcms/cms/src/Models/Theme.php
+++ b/packages/tallcms/cms/src/Models/Theme.php
@@ -290,11 +290,24 @@ class Theme
     }
 
     /**
-     * Check if theme supports runtime theme switching (theme-controller)
+     * Check if theme supports runtime theme switching (theme-controller).
+     * Note: this is preset-count derived, not theme.json-driven, for legacy reasons —
+     * the supports.theme_controller key in theme.json is advisory metadata only.
+     * The two methods below honor theme.json directly because they have no runtime equivalent.
      */
     public function supportsThemeController(): bool
     {
         return count($this->getDaisyUIPresets()) > 1;
+    }
+
+    public function supportsSearch(): bool
+    {
+        return $this->supports('search');
+    }
+
+    public function supportsLanguageSwitcher(): bool
+    {
+        return $this->supports('language_switcher');
     }
 
     /**

--- a/packages/tallcms/cms/src/helpers.php
+++ b/packages/tallcms/cms/src/helpers.php
@@ -254,6 +254,47 @@ if (! function_exists('supports_theme_controller')) {
     }
 }
 
+if (! function_exists('tallcms_show_theme_switcher')) {
+    function tallcms_show_theme_switcher(): bool
+    {
+        if (! (active_theme()?->supportsThemeController() ?? false)) {
+            return false;
+        }
+
+        return (bool) \TallCms\Cms\Models\SiteSetting::get('show_theme_switcher', true);
+    }
+}
+
+if (! function_exists('tallcms_show_search')) {
+    function tallcms_show_search(): bool
+    {
+        if (! (active_theme()?->supportsSearch() ?? false)) {
+            return false;
+        }
+
+        if (! config('tallcms.search.enabled', true)) {
+            return false;
+        }
+
+        return (bool) \TallCms\Cms\Models\SiteSetting::get('show_search', true);
+    }
+}
+
+if (! function_exists('tallcms_show_language_dropdown')) {
+    function tallcms_show_language_dropdown(): bool
+    {
+        if (! (active_theme()?->supportsLanguageSwitcher() ?? false)) {
+            return false;
+        }
+
+        if (! tallcms_i18n_enabled()) {
+            return false;
+        }
+
+        return (bool) \TallCms\Cms\Models\SiteSetting::get('show_language_dropdown', true);
+    }
+}
+
 if (! function_exists('theme_asset')) {
     /**
      * Get theme asset URL with fallback

--- a/packages/tallcms/cms/tests/Unit/ThemeUiToggleHelpersTest.php
+++ b/packages/tallcms/cms/tests/Unit/ThemeUiToggleHelpersTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace TallCms\Cms\Tests\Unit;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Mockery;
+use TallCms\Cms\Models\SiteSetting;
+use TallCms\Cms\Models\Theme;
+use TallCms\Cms\Tests\TestCase;
+
+/**
+ * Coverage for tallcms_show_theme_switcher / tallcms_show_search /
+ * tallcms_show_language_dropdown. Each helper composes:
+ *   - theme support gate (active_theme()->supports*)
+ *   - relevant global config flag
+ *   - per-site SiteSetting toggle (default true)
+ */
+class ThemeUiToggleHelpersTest extends TestCase
+{
+    protected function defineDatabaseMigrations(): void
+    {
+        parent::defineDatabaseMigrations();
+
+        Schema::create('tallcms_site_settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+            $table->string('type')->default('text');
+            $table->string('group')->default('general');
+            $table->text('description')->nullable();
+            $table->timestamps();
+            $table->index(['key', 'group']);
+        });
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('tallcms.search.enabled', true);
+        config()->set('tallcms.i18n.enabled', false);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /**
+     * Bind a stub Theme as the active theme.
+     *
+     * Note: supportsThemeController() is preset-count derived (not the supports
+     * flag), so callers controlling that gate must vary $presetsAll, not the
+     * supports['theme_controller'] key.
+     */
+    protected function bindActiveTheme(array $supports, bool $presetsAll = true): void
+    {
+        $themeData = [
+            'name' => 'Test',
+            'slug' => 'test-theme',
+            'daisyui' => array_filter([
+                'preset' => 'light',
+                'presets' => $presetsAll ? 'all' : null,
+            ]),
+            'supports' => $supports,
+        ];
+
+        $theme = new Theme($themeData, '/tmp/test-theme');
+
+        $manager = Mockery::mock(\TallCms\Cms\Services\ThemeManager::class);
+        $manager->shouldReceive('getActiveTheme')->andReturn($theme);
+        $manager->shouldReceive('themeAsset')->andReturn('');
+        $this->app->instance(\TallCms\Cms\Services\ThemeManager::class, $manager);
+    }
+
+    public function test_theme_switcher_helper_requires_theme_support(): void
+    {
+        // Single preset → supportsThemeController() returns false
+        $this->bindActiveTheme(supports: [], presetsAll: false);
+        $this->assertFalse(tallcms_show_theme_switcher());
+    }
+
+    public function test_theme_switcher_helper_respects_site_setting(): void
+    {
+        $this->bindActiveTheme(supports: [], presetsAll: true);
+
+        SiteSetting::set('show_theme_switcher', false, 'boolean', 'branding');
+        $this->assertFalse(tallcms_show_theme_switcher());
+
+        SiteSetting::set('show_theme_switcher', true, 'boolean', 'branding');
+        $this->assertTrue(tallcms_show_theme_switcher());
+    }
+
+    public function test_search_helper_requires_theme_support(): void
+    {
+        $this->bindActiveTheme(['search' => false]);
+        $this->assertFalse(tallcms_show_search());
+    }
+
+    public function test_search_helper_respects_global_config_flag(): void
+    {
+        $this->bindActiveTheme(['search' => true]);
+        config()->set('tallcms.search.enabled', false);
+        SiteSetting::set('show_search', true, 'boolean', 'branding');
+        $this->assertFalse(tallcms_show_search());
+    }
+
+    public function test_search_helper_respects_site_setting(): void
+    {
+        $this->bindActiveTheme(['search' => true]);
+        config()->set('tallcms.search.enabled', true);
+
+        SiteSetting::set('show_search', false, 'boolean', 'branding');
+        $this->assertFalse(tallcms_show_search());
+
+        SiteSetting::set('show_search', true, 'boolean', 'branding');
+        $this->assertTrue(tallcms_show_search());
+    }
+
+    public function test_language_dropdown_helper_requires_i18n_enabled(): void
+    {
+        $this->bindActiveTheme(['language_switcher' => true]);
+        config()->set('tallcms.i18n.enabled', false);
+        SiteSetting::set('show_language_dropdown', true, 'boolean', 'branding');
+        $this->assertFalse(tallcms_show_language_dropdown());
+    }
+
+    public function test_language_dropdown_helper_returns_true_when_all_conditions_met(): void
+    {
+        $this->bindActiveTheme(['language_switcher' => true]);
+        config()->set('tallcms.i18n.enabled', true);
+        SiteSetting::set('show_language_dropdown', true, 'boolean', 'branding');
+
+        $this->assertTrue(tallcms_show_language_dropdown());
+    }
+
+    public function test_helpers_default_to_true_when_setting_unset_but_theme_supports(): void
+    {
+        $this->bindActiveTheme(supports: ['search' => true], presetsAll: true);
+
+        // No SiteSetting written — defaults must keep controls visible.
+        $this->assertTrue(tallcms_show_theme_switcher());
+        $this->assertTrue(tallcms_show_search());
+    }
+}

--- a/themes/talldaisy/resources/views/layouts/app.blade.php
+++ b/themes/talldaisy/resources/views/layouts/app.blade.php
@@ -139,13 +139,17 @@
 
                     <div class="navbar-end gap-2">
                         <!-- Search -->
-                        @include('theme.talldaisy::components.header-search')
+                        @if(tallcms_show_search())
+                            @include('theme.talldaisy::components.header-search')
+                        @endif
 
                         <!-- Language Switcher -->
-                        @include('theme.talldaisy::components.language-switcher')
+                        @if(tallcms_show_language_dropdown())
+                            @include('theme.talldaisy::components.language-switcher')
+                        @endif
 
                         <!-- Theme Switcher -->
-                        @if(supports_theme_controller())
+                        @if(tallcms_show_theme_switcher())
                             @include('theme.talldaisy::components.theme-switcher')
                         @endif
                     </div>

--- a/themes/talldaisy/theme.json
+++ b/themes/talldaisy/theme.json
@@ -13,6 +13,8 @@
     "supports": {
         "dark_mode": true,
         "theme_controller": true,
+        "search": true,
+        "language_switcher": true,
         "responsive": true,
         "animations": true
     },


### PR DESCRIPTION
## Summary

- Three new SiteSetting-backed toggles let admins hide the theme switcher, search box, or language dropdown per site, surfaced in the Theme Manager slide-over alongside the Delete action.
- Toggles render only when the **active** theme declares it supports that specific control (via `theme.json supports.{search,language_switcher,theme_controller}`); inactive themes do not expose editable toggles to avoid mutating the active site's display state from an unrelated panel.
- Defaults are `true`, so existing installations keep current rendering on upgrade.
- `make:theme` scaffolding gains prompts (and CLI flags) to include search / language-switcher components, generating matching stubs, `theme.json supports` flags, and helper-guarded layout includes.

## Architecture

- **Theme model** gets `supportsSearch()` / `supportsLanguageSwitcher()` delegating to the generic `supports($key)` accessor. `supportsThemeController()` is intentionally **not** changed (still preset-count derived) — avoids behavior drift for themes that don't declare `supports.theme_controller` in JSON.
- **Three helpers** in `helpers.php` compose: `active_theme()->supports*()` + relevant global config flag (`tallcms.search.enabled` / `tallcms_i18n_enabled()`) + per-site `SiteSetting::get($key, true)`.
- **SiteSetting keys** registered in both `EditSite::$settingKeys` and `GlobalDefaults::$settingKeys` with explicit `match` arms in each `mount()` for the `true` default and in `GlobalDefaults::save()` for the `branding` group (mirrors `show_powered_by`).
- **Theme Manager slide-over** gets a new Display Options section between Color Palette and Features grid. The outer `@if(\$themeDetails['isActive'] && ...)` is the safety gate; per-toggle inner `@if`s render only the controls the active theme declares it supports. Toggles use `wire:model.live` with `updated*` hooks calling `SiteSetting::set()` (site-aware — writes to the override table when a site is in admin context, global table otherwise).
- **talldaisy** declares `supports.search` and `supports.language_switcher`; layout `@include`s now wrapped with the new helpers.

## Files changed

- `packages/tallcms/cms/src/Models/Theme.php` — 2 new supports methods
- `packages/tallcms/cms/src/helpers.php` — 3 new helpers
- `packages/tallcms/cms/src/Filament/Resources/SiteResource/Pages/EditSite.php` — 3 keys + match arm
- `packages/tallcms/cms/src/Filament/Pages/GlobalDefaults.php` — 3 keys + match arms + 3 Toggle fields
- `packages/tallcms/cms/src/Filament/Pages/ThemeManager.php` — 3 Livewire props + hydration in `showThemeDetails` + 3 `updated*` hooks
- `packages/tallcms/cms/resources/views/filament/pages/theme-manager.blade.php` — Display Options section
- `packages/tallcms/cms/src/Console/Commands/MakeTheme.php` — prompts, options, theme.json supports, component stubs, layout wiring
- `packages/tallcms/cms/tests/Unit/ThemeUiToggleHelpersTest.php` — 8 tests
- `themes/talldaisy/theme.json` — declare `supports.search` + `supports.language_switcher`
- `themes/talldaisy/resources/views/layouts/app.blade.php` — swap 3 conditionals

10 files. No migrations.

## Test plan

- [x] **8 helper unit tests pass.** Cover: support gate, global config gate (search.enabled / i18n.enabled), per-site override flips, default-true behavior.
- [x] **Full package suite (608 tests) green** — was 600 before, +8 from this branch.
- [x] **Asset build clean** (`npm run build`).
- [x] **Hide one control, verify others stay.** Theme Manager → talldaisy slide-over → toggle "Show search" off → reload talldaisy frontend → search disappears, theme switcher and language dropdown remain. Toggle back on → search returns.
- [x] **Active-theme gate.** With talldaisy active, open an inactive theme's slide-over → confirm Display Options section is **not** rendered.
- [x] **Theme support gate.** With elevate active (or any theme that only declares `theme_controller`), open the slide-over → confirm only the "Show theme switcher" toggle renders.
- [x] **Multisite per-site override.** With multisite enabled, hide search on Site A only → confirm Site A frontend hides search and Site B's still shows it.
- [x] **`make:theme` flow.** `php artisan make:theme TestTheme --all-presets --include-search --include-language-switcher` → confirm `theme.json` has all three `supports.*` flags, three component stubs exist under `resources/views/components/`, layout `@include`s wrapped in helpers, activate on a site, toggles control visibility.