### PR TITLE
Multi-word search + recently-used row in CmsRichEditor picker

### DIFF
--- a/packages/tallcms/cms/resources/views/filament/forms/components/cms-rich-editor.blade.php
+++ b/packages/tallcms/cms/resources/views/filament/forms/components/cms-rich-editor.blade.php
@@ -218,21 +218,81 @@
                                         blocks: @js($groupedBlocks),
                                         categories: @js($blockCategories),
                                         componentKey: @js($key),
-                                        expandedCategories: Object.keys(@js($groupedBlocks)),
+                                        expandedCategories: ['recent', ...Object.keys(@js($groupedBlocks))],
                                         editorSelectionWarned: false,
+                                        recentBlockIds: [],
+                                        maxRecentBlocks: 5,
+                                        storageKey: 'tallcms.editor.recentBlocks',
+
+                                        init() {
+                                            try {
+                                                const stored = localStorage.getItem(this.storageKey);
+                                                if (stored) {
+                                                    const parsed = JSON.parse(stored);
+                                                    if (Array.isArray(parsed)) this.recentBlockIds = parsed;
+                                                }
+                                            } catch (e) { /* private mode or bad JSON: ignore */ }
+                                        },
+
+                                        get isSearching() {
+                                            return this.searchQuery.trim().length > 0;
+                                        },
+
+                                        get searchTerms() {
+                                            return this.searchQuery.toLowerCase().trim().split(/\s+/).filter(Boolean);
+                                        },
+
+                                        rankBlock(block) {
+                                            const label = block.label.toLowerCase();
+                                            const id = block.id.toLowerCase();
+                                            const first = this.searchTerms[0] ?? '';
+                                            if (label === first) return 0;
+                                            if (label.startsWith(first)) return 1;
+                                            if (label.includes(first)) return 2;
+                                            if (id.includes(first)) return 3;
+                                            return 4;
+                                        },
 
                                         get filteredBlocks() {
-                                            const query = this.searchQuery.toLowerCase().trim().replace(/\s+/g, ' ');
-                                            if (!query) return this.blocks;
-
+                                            if (!this.isSearching) return this.blocks;
+                                            const terms = this.searchTerms;
                                             const result = {};
                                             for (const [cat, catBlocks] of Object.entries(this.blocks)) {
-                                                const filtered = catBlocks.filter(b => b.searchable.includes(query));
-                                                if (filtered.length > 0) {
-                                                    result[cat] = filtered;
-                                                }
+                                                const filtered = catBlocks
+                                                    .filter(b => terms.every(t => b.searchable.includes(t)))
+                                                    .sort((a, b) => this.rankBlock(a) - this.rankBlock(b));
+                                                if (filtered.length > 0) result[cat] = filtered;
                                             }
                                             return result;
+                                        },
+
+                                        get blockLookup() {
+                                            const lookup = {};
+                                            for (const catBlocks of Object.values(this.blocks)) {
+                                                for (const b of catBlocks) lookup[b.id] = b;
+                                            }
+                                            return lookup;
+                                        },
+
+                                        get recentBlocks() {
+                                            if (this.isSearching) return [];
+                                            const lookup = this.blockLookup;
+                                            return this.recentBlockIds
+                                                .map(id => lookup[id])
+                                                .filter(Boolean)
+                                                .slice(0, this.maxRecentBlocks);
+                                        },
+
+                                        get displayedBlocks() {
+                                            if (this.isSearching) return this.filteredBlocks;
+                                            const result = {};
+                                            if (this.recentBlocks.length > 0) result['recent'] = this.recentBlocks;
+                                            Object.assign(result, this.blocks);
+                                            return result;
+                                        },
+
+                                        get effectiveCategories() {
+                                            return { recent: { label: 'Recently used' }, ...this.categories };
                                         },
 
                                         get totalFilteredCount() {
@@ -240,7 +300,7 @@
                                         },
 
                                         get hasMultipleCategories() {
-                                            return Object.keys(this.filteredBlocks).length > 1;
+                                            return Object.keys(this.displayedBlocks).length > 1;
                                         },
 
                                         isExpanded(category) {
@@ -255,7 +315,17 @@
                                             }
                                         },
 
+                                        rememberBlock(blockId) {
+                                            const next = [blockId, ...this.recentBlockIds.filter(id => id !== blockId)]
+                                                .slice(0, this.maxRecentBlocks);
+                                            this.recentBlockIds = next;
+                                            try {
+                                                localStorage.setItem(this.storageKey, JSON.stringify(next));
+                                            } catch (e) { /* storage unavailable: in-memory only */ }
+                                        },
+
                                         insertBlock(blockId, selection) {
+                                            this.rememberBlock(blockId);
                                             $wire.mountAction(
                                                 'customBlock',
                                                 { editorSelection: selection, id: blockId, mode: 'insert' },
@@ -279,7 +349,7 @@
 
                                     {{-- Grouped Blocks --}}
                                     <div class="fi-cms-block-categories flex-1 overflow-y-auto">
-                                        <template x-for="(catBlocks, category) in filteredBlocks" :key="category">
+                                        <template x-for="(catBlocks, category) in displayedBlocks" :key="category">
                                             <div class="fi-cms-block-category" x-show="catBlocks.length > 0">
                                                 {{-- Collapsible Category Header --}}
                                                 <template x-if="hasMultipleCategories">
@@ -288,7 +358,7 @@
                                                         x-on:click="toggleCategory(category)"
                                                         class="fi-cms-block-category-heading sticky top-0 z-10 flex w-full items-center justify-between gap-2 px-3 py-2 text-start text-xs font-semibold uppercase tracking-wider transition-colors"
                                                     >
-                                                        <span x-text="categories[category]?.label ?? 'Other'"></span>
+                                                        <span x-text="effectiveCategories[category]?.label ?? 'Other'"></span>
                                                         <span class="transition-transform duration-200" :class="{ 'rotate-180': isExpanded(category) }">
                                                             {!! \Filament\Support\generate_icon_html('heroicon-m-chevron-down', 'h-4 w-4')->toHtml() !!}
                                                         </span>

--- a/packages/tallcms/cms/resources/views/filament/forms/components/cms-rich-editor.blade.php
+++ b/packages/tallcms/cms/resources/views/filament/forms/components/cms-rich-editor.blade.php
@@ -393,7 +393,7 @@
                                                                 isLoading = true;
                                                                 insertBlock(block.id, editorSelection);
                                                             "
-                                                            x-on:dragstart="$event.dataTransfer.setData('customBlock', block.id)"
+                                                            x-on:dragstart="$event.dataTransfer.setData('customBlock', block.id); rememberBlock(block.id)"
                                                             x-on:open-modal.window="isLoading = false"
                                                             x-on:run-rich-editor-commands.window="isLoading = false"
                                                             class="fi-fo-rich-editor-custom-block-btn fi-cms-block-btn flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-start text-sm transition-colors hover:bg-gray-100 dark:hover:bg-white/5"


### PR DESCRIPTION
## Summary

- **Multi-word search** — query is split on whitespace and all terms must appear in a block's `searchable` string (any order). Today's substring match fails on "form contact" → won't find Contact Form. Now it does.
- **Result ranking** — within each category, search hits sort by relevance: exact label > `startsWith` > `includes` > id contains > anywhere in description/keywords. Category grouping is preserved (no jarring switch to a flat list).
- **Recently used row** — a synthetic "Recently used" pseudo-category renders above the regular categories when not searching, capped at the last 5 inserted blocks. Backed by `localStorage` (`tallcms.editor.recentBlocks`); stored IDs that no longer resolve to a registered block (e.g. removed custom blocks) are silently skipped.

This is **PR 2** of the Phase 2 Rich Editor series. Independent of PR 1 (sticky panel) — different file, can merge in any order. Blade/Alpine only — no CSS, no PHP, no rebuilt artifacts.

## Implementation notes

- Synthetic `recent` category piggybacks on the existing `displayedBlocks` iteration via a single getter — no duplicated button markup.
- `localStorage` reads/writes are wrapped in `try/catch` so private-mode browsers degrade to in-memory recents instead of throwing.
- `init()` rejects non-array stored values defensively.
- `hasMultipleCategories` now derives from `displayedBlocks` (not `filteredBlocks`) so the "Recently used" header always labels itself when present alongside the normal categories.

## Test plan

- [ ] Search for "form contact" — Contact Form appears (regression: previously empty results)
- [ ] Search for "hero" — Hero block ranks above other matches in its category
- [ ] Insert a few blocks, refresh the page — they appear under "Recently used" at the top of the picker
- [ ] Insert a block that's already in Recents — moves to the front (no duplicates)
- [ ] After 6+ inserts of distinct blocks, only the most recent 5 are kept
- [ ] Delete a custom block whose ID is in Recents — picker silently skips it on next render
- [ ] Private-mode / disabled `localStorage` — picker still works, recents list is in-memory only
- [ ] Search box clears → "Recently used" row reappears
- [ ] `RichEditorViteGuardTest` still passes (sanity check that Blade compiles)