### PR TITLE
Improve CMS page rendering cache performance

### DIFF
--- a/packages/tallcms/cms/src/Models/CmsPage.php
+++ b/packages/tallcms/cms/src/Models/CmsPage.php
@@ -22,6 +22,7 @@ use TallCms\Cms\Models\Concerns\HasRevisions;
 use TallCms\Cms\Models\Concerns\HasSearchableContent;
 use TallCms\Cms\Models\Concerns\HasTranslatableContent;
 use TallCms\Cms\Services\CustomBlockDiscoveryService;
+use TallCms\Cms\Support\MenuCache;
 
 class CmsPage extends Model implements HasRichContent
 {
@@ -176,8 +177,15 @@ class CmsPage extends Model implements HasRichContent
         });
 
         static::saved(function ($page) {
+            if ($page->wasRecentlyCreated || $page->wasChanged(['slug', 'parent_id', 'is_homepage'])) {
+                MenuCache::flush();
+            }
+
             MediaLibraryFileAttachmentProvider::syncAltTextFromContent($page->content);
         });
+
+        static::deleted(fn (): bool => MenuCache::flush());
+        static::restored(fn (): bool => MenuCache::flush());
     }
 
     public function parent(): BelongsTo

--- a/packages/tallcms/cms/src/Models/SiteSetting.php
+++ b/packages/tallcms/cms/src/Models/SiteSetting.php
@@ -11,6 +11,16 @@ use Illuminate\Support\Facades\DB;
 
 class SiteSetting extends Model
 {
+    protected const CACHE_PAYLOAD_MARKER = '__tallcms_site_setting_cache';
+
+    protected const GLOBAL_SETTINGS_MEMO_ATTRIBUTE = 'tallcms.site_setting_globals';
+
+    protected const SITE_OVERRIDES_MEMO_ATTRIBUTE = 'tallcms.site_setting_overrides';
+
+    protected const CURRENT_SITE_ID_MEMOIZED_ATTRIBUTE = 'tallcms.current_site_id_memoized';
+
+    protected const CURRENT_SITE_ID_ATTRIBUTE = 'tallcms.current_site_id';
+
     protected $table = 'tallcms_site_settings';
 
     protected $fillable = [
@@ -90,18 +100,35 @@ class SiteSetting extends Model
         if ($siteId) {
             $siteCacheKey = "site_setting_{$siteId}_{$key}";
 
-            $override = Cache::remember($siteCacheKey, 3600, function () use ($siteId, $key) {
-                try {
-                    return DB::table('tallcms_site_setting_overrides')
-                        ->where('site_id', $siteId)
-                        ->where('key', $key)
-                        ->first();
-                } catch (QueryException) {
-                    return null;
-                }
-            });
+            $override = static::memoizedSettingPayload(
+                static::SITE_OVERRIDES_MEMO_ATTRIBUTE,
+                $siteCacheKey,
+                fn (): mixed => Cache::remember($siteCacheKey, 3600, function () use ($siteId, $key) {
+                    try {
+                        $override = DB::table('tallcms_site_setting_overrides')
+                            ->where('site_id', $siteId)
+                            ->where('key', $key)
+                            ->first();
 
-            if ($override) {
+                        if (!$override) {
+                            return static::missingCachePayload();
+                        }
+
+                        return static::cachePayload([
+                            'value' => $override->value,
+                            'type' => $override->type,
+                        ]);
+                    } catch (QueryException) {
+                        return static::missingCachePayload();
+                    }
+                })
+            );
+
+            if (static::isCachePayload($override)) {
+                if ($override['exists'] ?? false) {
+                    return static::castOverrideValue($override['value'], $override['type']);
+                }
+            } elseif ($override) {
                 return static::castOverrideValue($override->value, $override->type);
             }
         }
@@ -120,24 +147,82 @@ class SiteSetting extends Model
     {
         $cacheKey = "site_setting_{$key}";
 
-        return Cache::remember($cacheKey, 3600, function () use ($key, $default) {
-            try {
-                $setting = static::where('key', $key)->first();
+        $setting = static::memoizedSettingPayload(
+            static::GLOBAL_SETTINGS_MEMO_ATTRIBUTE,
+            $cacheKey,
+            fn (): mixed => Cache::remember($cacheKey, 3600, function () use ($key) {
+                try {
+                    $setting = static::where('key', $key)->first();
 
-                if (! $setting) {
-                    return $default;
+                    if (!$setting) {
+                        return static::missingCachePayload();
+                    }
+
+                    return static::cachePayload([
+                        'value' => match ($setting->type) {
+                            'boolean' => filter_var($setting->value, FILTER_VALIDATE_BOOLEAN),
+                            'json' => json_decode($setting->value, true),
+                            'file' => $setting->value,
+                            default => $setting->value,
+                        },
+                    ]);
+                } catch (QueryException) {
+                    return static::missingCachePayload();
                 }
+            })
+        );
 
-                return match ($setting->type) {
-                    'boolean' => filter_var($setting->value, FILTER_VALIDATE_BOOLEAN),
-                    'json' => json_decode($setting->value, true),
-                    'file' => $setting->value,
-                    default => $setting->value,
-                };
-            } catch (QueryException) {
-                return $default;
-            }
-        });
+        if (static::isCachePayload($setting)) {
+            return ($setting['exists'] ?? false) ? $setting['value'] : $default;
+        }
+
+        return $setting;
+    }
+
+    /**
+     * Cache payload wrapper used so missing/null settings are cached as real values.
+     *
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>
+     */
+    protected static function cachePayload(array $data): array
+    {
+        return [
+            static::CACHE_PAYLOAD_MARKER => true,
+            'exists' => true,
+            ...$data,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected static function missingCachePayload(): array
+    {
+        return [
+            static::CACHE_PAYLOAD_MARKER => true,
+            'exists' => false,
+        ];
+    }
+
+    protected static function isCachePayload(mixed $value): bool
+    {
+        return is_array($value) && ($value[static::CACHE_PAYLOAD_MARKER] ?? false) === true;
+    }
+
+    protected static function memoizedSettingPayload(string $attribute, string $key, callable $resolver): mixed
+    {
+        $request = request();
+        $memoizedSettings = $request->attributes->get($attribute, []);
+
+        if (array_key_exists($key, $memoizedSettings)) {
+            return $memoizedSettings[$key];
+        }
+
+        $memoizedSettings[$key] = $resolver();
+        $request->attributes->set($attribute, $memoizedSettings);
+
+        return $memoizedSettings[$key];
     }
 
     /**
@@ -156,34 +241,40 @@ class SiteSetting extends Model
      */
     protected static function resolveCurrentSiteId(): ?int
     {
+        $request = request();
+
+        if ($request->attributes->get(static::CURRENT_SITE_ID_MEMOIZED_ATTRIBUTE, false)) {
+            return $request->attributes->get(static::CURRENT_SITE_ID_ATTRIBUTE);
+        }
+
+        $siteId = null;
         $isAdminContext = request()?->attributes->get('tallcms.admin_context', false);
 
         if ($isAdminContext) {
             // Admin: session is the source of truth (immune to stale resolver)
             $sessionValue = session('multisite_admin_site_id');
             if ($sessionValue && $sessionValue !== '__all_sites__' && is_numeric($sessionValue)) {
-                return (int) $sessionValue;
+                $siteId = (int) $sessionValue;
             }
-
-            return null; // "All Sites" or no selection
-        }
-
-        // Frontend / non-admin with multisite plugin: resolver is authoritative (domain-based)
-        if (app()->bound('tallcms.multisite.resolver')) {
+        } elseif (app()->bound('tallcms.multisite.resolver')) {
+            // Frontend / non-admin with multisite plugin: resolver is authoritative (domain-based)
             try {
                 $resolver = app('tallcms.multisite.resolver');
                 if ($resolver->isResolved() && $resolver->id()) {
-                    return $resolver->id();
+                    $siteId = $resolver->id();
                 }
             } catch (\Throwable) {
                 // Resolver not functional
             }
-
-            return null;
+        } else {
+            // Single-site install: default site is always the current site.
+            $siteId = static::defaultSiteId();
         }
 
-        // Single-site install: default site is always the current site.
-        return static::defaultSiteId();
+        $request->attributes->set(static::CURRENT_SITE_ID_ATTRIBUTE, $siteId);
+        $request->attributes->set(static::CURRENT_SITE_ID_MEMOIZED_ATTRIBUTE, true);
+
+        return $siteId;
     }
 
     /**
@@ -194,6 +285,8 @@ class SiteSetting extends Model
      */
     protected static ?int $memoizedDefaultSiteId = null;
 
+    protected static ?string $memoizedDefaultSiteName = null;
+
     protected static bool $defaultSiteIdMemoized = false;
 
     protected static function defaultSiteId(): ?int
@@ -203,11 +296,19 @@ class SiteSetting extends Model
         }
 
         try {
-            $id = DB::table('tallcms_sites')->where('is_default', true)->value('id')
-                ?? DB::table('tallcms_sites')->orderBy('id')->value('id');
-            static::$memoizedDefaultSiteId = $id ? (int) $id : null;
+            $site = DB::table('tallcms_sites')
+                ->where('is_default', true)
+                ->select(['id', 'name'])
+                ->first() ?? DB::table('tallcms_sites')
+                ->orderBy('id')
+                ->select(['id', 'name'])
+                ->first();
+
+            static::$memoizedDefaultSiteId = $site?->id ? (int) $site->id : null;
+            static::$memoizedDefaultSiteName = is_string($site?->name) && $site->name !== '' ? $site->name : null;
         } catch (\Throwable) {
             static::$memoizedDefaultSiteId = null;
+            static::$memoizedDefaultSiteName = null;
         }
 
         static::$defaultSiteIdMemoized = true;
@@ -221,7 +322,21 @@ class SiteSetting extends Model
     public static function forgetMemoizedDefaultSiteId(): void
     {
         static::$memoizedDefaultSiteId = null;
+        static::$memoizedDefaultSiteName = null;
         static::$defaultSiteIdMemoized = false;
+
+        request()?->attributes->remove('tallcms.site_names');
+        static::forgetRequestMemoizedSettings();
+    }
+
+    protected static function forgetRequestMemoizedSettings(): void
+    {
+        $request = request();
+
+        $request->attributes->remove(static::GLOBAL_SETTINGS_MEMO_ATTRIBUTE);
+        $request->attributes->remove(static::SITE_OVERRIDES_MEMO_ATTRIBUTE);
+        $request->attributes->remove(static::CURRENT_SITE_ID_ATTRIBUTE);
+        $request->attributes->remove(static::CURRENT_SITE_ID_MEMOIZED_ATTRIBUTE);
     }
 
     /**
@@ -243,7 +358,9 @@ class SiteSetting extends Model
             $siteId = static::resolveCurrentSiteId();
 
             if ($siteId) {
-                $name = DB::table('tallcms_sites')->where('id', $siteId)->value('name');
+                $name = static::memoizedDefaultSiteName($siteId)
+                    ?? static::memoizedSiteName("site:{$siteId}", fn (): ?string => DB::table('tallcms_sites')->where('id', $siteId)->value('name'));
+
                 if ($name) {
                     return $name;
                 }
@@ -256,7 +373,7 @@ class SiteSetting extends Model
             }
 
             // Fallback: default site's name
-            $name = DB::table('tallcms_sites')->where('is_default', true)->value('name');
+            $name = static::memoizedSiteName('default', fn (): ?string => DB::table('tallcms_sites')->where('is_default', true)->value('name'));
             if ($name) {
                 return $name;
             }
@@ -264,6 +381,31 @@ class SiteSetting extends Model
         }
 
         return $default ?? config('app.name', 'My Site');
+    }
+
+    protected static function memoizedDefaultSiteName(int $siteId): ?string
+    {
+        if (!static::$defaultSiteIdMemoized || static::$memoizedDefaultSiteId !== $siteId) {
+            return null;
+        }
+
+        return static::$memoizedDefaultSiteName;
+    }
+
+    protected static function memoizedSiteName(string $key, callable $resolver): ?string
+    {
+        $request = request();
+        $names = $request->attributes->get('tallcms.site_names', []);
+
+        if (array_key_exists($key, $names)) {
+            return $names[$key];
+        }
+
+        $name = $resolver();
+        $names[$key] = is_string($name) && $name !== '' ? $name : null;
+        $request->attributes->set('tallcms.site_names', $names);
+
+        return $names[$key];
     }
 
     /**
@@ -349,6 +491,7 @@ class SiteSetting extends Model
                     ]
                 );
                 Cache::forget("site_setting_{$siteId}_{$key}");
+                static::forgetRequestMemoizedSettings();
 
                 return;
             } catch (\Throwable) {
@@ -382,6 +525,7 @@ class SiteSetting extends Model
         );
 
         Cache::forget("site_setting_{$key}");
+        static::forgetRequestMemoizedSettings();
     }
 
     /**
@@ -393,7 +537,7 @@ class SiteSetting extends Model
     public static function resetToGlobal(string $key): void
     {
         $siteId = static::resolveCurrentSiteId();
-        if (! $siteId) {
+        if (!$siteId) {
             return;
         }
 
@@ -403,6 +547,7 @@ class SiteSetting extends Model
                 ->where('key', $key)
                 ->delete();
             Cache::forget("site_setting_{$siteId}_{$key}");
+            static::forgetRequestMemoizedSettings();
         } catch (\Throwable) {
             // Ignore — table may not exist
         }
@@ -437,6 +582,7 @@ class SiteSetting extends Model
     public static function clearCache(): void
     {
         static::forgetMemoizedDefaultSiteId();
+        static::forgetRequestMemoizedSettings();
 
         try {
             $settings = static::all();

--- a/packages/tallcms/cms/src/Models/SiteSetting.php
+++ b/packages/tallcms/cms/src/Models/SiteSetting.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use TallCms\Cms\Support\MenuCache;
 
 class SiteSetting extends Model
 {
@@ -20,6 +21,14 @@ class SiteSetting extends Model
     protected const CURRENT_SITE_ID_MEMOIZED_ATTRIBUTE = 'tallcms.current_site_id_memoized';
 
     protected const CURRENT_SITE_ID_ATTRIBUTE = 'tallcms.current_site_id';
+
+    protected const MENU_URL_SETTING_KEYS = [
+        'site_type',
+        'i18n_enabled',
+        'default_locale',
+        'hide_default_locale',
+        'i18n_locale_overrides',
+    ];
 
     protected $table = 'tallcms_site_settings';
 
@@ -110,7 +119,7 @@ class SiteSetting extends Model
                             ->where('key', $key)
                             ->first();
 
-                        if (!$override) {
+                        if (! $override) {
                             return static::missingCachePayload();
                         }
 
@@ -154,7 +163,7 @@ class SiteSetting extends Model
                 try {
                     $setting = static::where('key', $key)->first();
 
-                    if (!$setting) {
+                    if (! $setting) {
                         return static::missingCachePayload();
                     }
 
@@ -182,7 +191,7 @@ class SiteSetting extends Model
     /**
      * Cache payload wrapper used so missing/null settings are cached as real values.
      *
-     * @param array<string, mixed> $data
+     * @param  array<string, mixed>  $data
      * @return array<string, mixed>
      */
     protected static function cachePayload(array $data): array
@@ -207,6 +216,7 @@ class SiteSetting extends Model
 
     protected static function isCachePayload(mixed $value): bool
     {
+        // Only arrays with the private marker are treated as cache payloads.
         return is_array($value) && ($value[static::CACHE_PAYLOAD_MARKER] ?? false) === true;
     }
 
@@ -339,6 +349,13 @@ class SiteSetting extends Model
         $request->attributes->remove(static::CURRENT_SITE_ID_MEMOIZED_ATTRIBUTE);
     }
 
+    public static function flushMenuCacheIfSettingAffectsMenuUrls(string $key): void
+    {
+        if (in_array($key, static::MENU_URL_SETTING_KEYS, true)) {
+            MenuCache::flush();
+        }
+    }
+
     /**
      * Resolve site_name from the Site model's name field.
      *
@@ -385,7 +402,7 @@ class SiteSetting extends Model
 
     protected static function memoizedDefaultSiteName(int $siteId): ?string
     {
-        if (!static::$defaultSiteIdMemoized || static::$memoizedDefaultSiteId !== $siteId) {
+        if (! static::$defaultSiteIdMemoized || static::$memoizedDefaultSiteId !== $siteId) {
             return null;
         }
 
@@ -426,11 +443,14 @@ class SiteSetting extends Model
                     ->where('id', $siteId)
                     ->update(['name' => $value]);
 
+                static::forgetMemoizedDefaultSiteId();
+
                 return;
             }
 
             // No site context: write to global setting (standalone behavior)
             static::setGlobal('site_name', $value, 'text', 'general');
+            static::forgetMemoizedDefaultSiteId();
         } catch (\Throwable) {
         }
     }
@@ -492,6 +512,7 @@ class SiteSetting extends Model
                 );
                 Cache::forget("site_setting_{$siteId}_{$key}");
                 static::forgetRequestMemoizedSettings();
+                static::flushMenuCacheIfSettingAffectsMenuUrls($key);
 
                 return;
             } catch (\Throwable) {
@@ -526,6 +547,7 @@ class SiteSetting extends Model
 
         Cache::forget("site_setting_{$key}");
         static::forgetRequestMemoizedSettings();
+        static::flushMenuCacheIfSettingAffectsMenuUrls($key);
     }
 
     /**
@@ -537,7 +559,7 @@ class SiteSetting extends Model
     public static function resetToGlobal(string $key): void
     {
         $siteId = static::resolveCurrentSiteId();
-        if (!$siteId) {
+        if (! $siteId) {
             return;
         }
 
@@ -548,6 +570,7 @@ class SiteSetting extends Model
                 ->delete();
             Cache::forget("site_setting_{$siteId}_{$key}");
             static::forgetRequestMemoizedSettings();
+            static::flushMenuCacheIfSettingAffectsMenuUrls($key);
         } catch (\Throwable) {
             // Ignore — table may not exist
         }

--- a/packages/tallcms/cms/src/Models/TallcmsMenu.php
+++ b/packages/tallcms/cms/src/Models/TallcmsMenu.php
@@ -6,6 +6,7 @@ namespace TallCms\Cms\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Cache;
 
 class TallcmsMenu extends Model
 {
@@ -22,6 +23,12 @@ class TallcmsMenu extends Model
     protected $casts = [
         'is_active' => 'boolean',
     ];
+
+    protected static function booted(): void
+    {
+        static::saved(fn (): bool => Cache::tags(['cms', 'cms:menus'])->flush());
+        static::deleted(fn (): bool => Cache::tags(['cms', 'cms:menus'])->flush());
+    }
 
     public function items(): HasMany
     {

--- a/packages/tallcms/cms/src/Models/TallcmsMenu.php
+++ b/packages/tallcms/cms/src/Models/TallcmsMenu.php
@@ -6,7 +6,7 @@ namespace TallCms\Cms\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Facades\Cache;
+use TallCms\Cms\Support\MenuCache;
 
 class TallcmsMenu extends Model
 {
@@ -26,8 +26,8 @@ class TallcmsMenu extends Model
 
     protected static function booted(): void
     {
-        static::saved(fn (): bool => Cache::tags(['cms', 'cms:menus'])->flush());
-        static::deleted(fn (): bool => Cache::tags(['cms', 'cms:menus'])->flush());
+        static::saved(fn (): bool => MenuCache::flush());
+        static::deleted(fn (): bool => MenuCache::flush());
     }
 
     public function items(): HasMany

--- a/packages/tallcms/cms/src/Models/TallcmsMenuItem.php
+++ b/packages/tallcms/cms/src/Models/TallcmsMenuItem.php
@@ -7,6 +7,7 @@ namespace TallCms\Cms\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Cache;
 use Kalnoy\Nestedset\NodeTrait;
 use TallCms\Cms\Models\Concerns\HasTranslatableContent;
 
@@ -40,6 +41,12 @@ class TallcmsMenuItem extends Model
         'meta' => 'array',
         'is_active' => 'boolean',
     ];
+
+    protected static function booted(): void
+    {
+        static::saved(fn (): bool => Cache::tags(['cms', 'cms:menus'])->flush());
+        static::deleted(fn (): bool => Cache::tags(['cms', 'cms:menus'])->flush());
+    }
 
     public function menu(): BelongsTo
     {

--- a/packages/tallcms/cms/src/Models/TallcmsMenuItem.php
+++ b/packages/tallcms/cms/src/Models/TallcmsMenuItem.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TallCms\Cms\Models;
 
+use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -46,6 +47,20 @@ class TallcmsMenuItem extends Model
     {
         static::saved(fn (): bool => MenuCache::flush());
         static::deleted(fn (): bool => MenuCache::flush());
+    }
+
+    /**
+     * Compatibility for kalnoy/nestedset v7 on Laravel 11.
+     */
+    protected static function whenBooted(Closure $callback)
+    {
+        if (method_exists(Model::class, 'whenBooted')) {
+            parent::whenBooted($callback);
+
+            return;
+        }
+
+        $callback();
     }
 
     public function menu(): BelongsTo

--- a/packages/tallcms/cms/src/Models/TallcmsMenuItem.php
+++ b/packages/tallcms/cms/src/Models/TallcmsMenuItem.php
@@ -7,9 +7,9 @@ namespace TallCms\Cms\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Facades\Cache;
 use Kalnoy\Nestedset\NodeTrait;
 use TallCms\Cms\Models\Concerns\HasTranslatableContent;
+use TallCms\Cms\Support\MenuCache;
 
 class TallcmsMenuItem extends Model
 {
@@ -44,8 +44,8 @@ class TallcmsMenuItem extends Model
 
     protected static function booted(): void
     {
-        static::saved(fn (): bool => Cache::tags(['cms', 'cms:menus'])->flush());
-        static::deleted(fn (): bool => Cache::tags(['cms', 'cms:menus'])->flush());
+        static::saved(fn (): bool => MenuCache::flush());
+        static::deleted(fn (): bool => MenuCache::flush());
     }
 
     public function menu(): BelongsTo

--- a/packages/tallcms/cms/src/Services/SiteSettingsService.php
+++ b/packages/tallcms/cms/src/Services/SiteSettingsService.php
@@ -6,6 +6,7 @@ namespace TallCms\Cms\Services;
 
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use TallCms\Cms\Models\SiteSetting;
 use TallCms\Cms\Models\SiteSettingOverride;
 
 /**
@@ -58,6 +59,7 @@ class SiteSettingsService
         );
 
         Cache::forget("site_setting_{$siteId}_{$key}");
+        SiteSetting::flushMenuCacheIfSettingAffectsMenuUrls($key);
     }
 
     /**
@@ -71,6 +73,7 @@ class SiteSettingsService
             ->delete();
 
         Cache::forget("site_setting_{$siteId}_{$key}");
+        SiteSetting::flushMenuCacheIfSettingAffectsMenuUrls($key);
     }
 
     /**

--- a/packages/tallcms/cms/src/Support/MenuCache.php
+++ b/packages/tallcms/cms/src/Support/MenuCache.php
@@ -14,7 +14,7 @@ class MenuCache
     /**
      * @template TCacheValue
      *
-     * @param Closure(): TCacheValue $callback
+     * @param  Closure(): TCacheValue  $callback
      * @return TCacheValue
      */
     public static function remember(string $key, mixed $ttl, Closure $callback): mixed
@@ -32,7 +32,7 @@ class MenuCache
     {
         self::incrementVersion();
 
-        if (!self::supportsTags()) {
+        if (! self::supportsTags()) {
             return true;
         }
 
@@ -46,7 +46,11 @@ class MenuCache
 
     private static function incrementVersion(): void
     {
-        Cache::forever(self::VersionKey, self::version() + 1);
+        Cache::add(self::VersionKey, 1, now()->addYears(10));
+
+        if (Cache::increment(self::VersionKey) === false) {
+            Cache::forever(self::VersionKey, self::version() + 1);
+        }
     }
 
     private static function supportsTags(): bool

--- a/packages/tallcms/cms/src/Support/MenuCache.php
+++ b/packages/tallcms/cms/src/Support/MenuCache.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TallCms\Cms\Support;
+
+use Closure;
+use Illuminate\Support\Facades\Cache;
+
+class MenuCache
+{
+    private const VersionKey = 'tallcms.menu.version';
+
+    /**
+     * @template TCacheValue
+     *
+     * @param Closure(): TCacheValue $callback
+     * @return TCacheValue
+     */
+    public static function remember(string $key, mixed $ttl, Closure $callback): mixed
+    {
+        $cacheKey = $key.'|v'.self::version();
+
+        if (self::supportsTags()) {
+            return Cache::tags(['cms', 'cms:menus'])->remember($cacheKey, $ttl, $callback);
+        }
+
+        return Cache::remember($cacheKey, $ttl, $callback);
+    }
+
+    public static function flush(): bool
+    {
+        self::incrementVersion();
+
+        if (!self::supportsTags()) {
+            return true;
+        }
+
+        return Cache::tags(['cms', 'cms:menus'])->flush();
+    }
+
+    private static function version(): int
+    {
+        return (int) Cache::get(self::VersionKey, 1);
+    }
+
+    private static function incrementVersion(): void
+    {
+        Cache::forever(self::VersionKey, self::version() + 1);
+    }
+
+    private static function supportsTags(): bool
+    {
+        return method_exists(Cache::getFacadeRoot(), 'supportsTags')
+            && Cache::supportsTags();
+    }
+}

--- a/packages/tallcms/cms/src/helpers.php
+++ b/packages/tallcms/cms/src/helpers.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use TallCms\Cms\Contracts\ThemeInterface;
 use TallCms\Cms\Models\CmsPage;
@@ -14,6 +13,7 @@ use TallCms\Cms\Services\LocaleRegistry;
 use TallCms\Cms\Services\PluginLicenseService;
 use TallCms\Cms\Services\ThemeManager;
 use TallCms\Cms\Services\ThemeResolver;
+use TallCms\Cms\Support\MenuCache;
 
 /**
  * TallCMS Helper Functions
@@ -545,26 +545,25 @@ if (!function_exists('menu')) {
             $request->getHost(),
         ]);
 
-        $cachedMenu = Cache::tags(['cms', 'cms:menus'])
-            ->remember($persistentCacheKey, now()->addHour(), function () use ($location): ?array {
-                $menu = TallcmsMenu::byLocation($location);
+        $cachedMenu = MenuCache::remember($persistentCacheKey, now()->addHour(), function () use ($location): ?array {
+            $menu = TallcmsMenu::byLocation($location);
 
-                if (!$menu) {
-                    return null;
-                }
+            if (!$menu) {
+                return null;
+            }
 
-                // Get all menu items for this menu and build the tree structure
-                $items = $menu->allItems()
-                    ->where('is_active', true)
-                    ->with('page')
-                    ->defaultOrder()
-                    ->get()
-                    ->toTree();
+            // Get all menu items for this menu and build the tree structure
+            $items = $menu->allItems()
+                ->where('is_active', true)
+                ->with('page')
+                ->defaultOrder()
+                ->get()
+                ->toTree();
 
-                return $items->map(function ($item) {
-                    return buildMenuItemArray($item, false);
-                })->toArray();
-            });
+            return $items->map(function ($item) {
+                return buildMenuItemArray($item, false);
+            })->toArray();
+        });
 
         $resolvedMenus[$cacheKey] = $cachedMenu === null
             ? null

--- a/packages/tallcms/cms/src/helpers.php
+++ b/packages/tallcms/cms/src/helpers.php
@@ -1,6 +1,19 @@
 <?php
 
 declare(strict_types=1);
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use TallCms\Cms\Contracts\ThemeInterface;
+use TallCms\Cms\Models\CmsPage;
+use TallCms\Cms\Models\CmsPost;
+use TallCms\Cms\Models\SiteSetting;
+use TallCms\Cms\Models\TallcmsMenu;
+use TallCms\Cms\Models\Theme;
+use TallCms\Cms\Services\LocaleRegistry;
+use TallCms\Cms\Services\PluginLicenseService;
+use TallCms\Cms\Services\ThemeManager;
+use TallCms\Cms\Services\ThemeResolver;
 
 /**
  * TallCMS Helper Functions
@@ -14,7 +27,7 @@ declare(strict_types=1);
 
 // URL Helper Functions
 
-if (! function_exists('tallcms_routes_prefix')) {
+if (!function_exists('tallcms_routes_prefix')) {
     /**
      * Get the configured routes prefix for CMS frontend routes
      *
@@ -29,7 +42,7 @@ if (! function_exists('tallcms_routes_prefix')) {
     }
 }
 
-if (! function_exists('tallcms_home_url')) {
+if (!function_exists('tallcms_home_url')) {
     /**
      * Get the CMS homepage URL, respecting routes prefix
      *
@@ -43,11 +56,11 @@ if (! function_exists('tallcms_home_url')) {
     }
 }
 
-if (! function_exists('tallcms_page_url')) {
+if (!function_exists('tallcms_page_url')) {
     /**
      * Get a CMS page URL by slug, respecting routes prefix
      *
-     * @param  string  $slug  The page slug (with or without leading slash)
+     * @param string $slug The page slug (with or without leading slash)
      * @return string The full URL to the page
      */
     function tallcms_page_url(string $slug): string
@@ -64,11 +77,11 @@ if (! function_exists('tallcms_page_url')) {
 
 // Filament Panel Helper Functions
 
-if (! function_exists('tallcms_panel_url')) {
+if (!function_exists('tallcms_panel_url')) {
     /**
      * Get the full URL to the Filament admin panel, optionally with a sub-path.
      *
-     * @param  string  $path  Optional sub-path to append (e.g., 'cms-pages/create')
+     * @param string $path Optional sub-path to append (e.g., 'cms-pages/create')
      * @return string The full URL to the panel
      */
     function tallcms_panel_url(string $path = ''): string
@@ -85,12 +98,12 @@ if (! function_exists('tallcms_panel_url')) {
     }
 }
 
-if (! function_exists('tallcms_panel_route')) {
+if (!function_exists('tallcms_panel_route')) {
     /**
      * Build a Filament route name dynamically using the configured panel ID.
      *
-     * @param  string  $suffix  The route suffix (e.g., 'pages.plugin-licenses')
-     * @param  mixed  $parameters  Optional route parameters
+     * @param string $suffix The route suffix (e.g., 'pages.plugin-licenses')
+     * @param mixed $parameters Optional route parameters
      * @return string The resolved route URL
      */
     function tallcms_panel_route(string $suffix, mixed $parameters = []): string
@@ -103,17 +116,17 @@ if (! function_exists('tallcms_panel_route')) {
 
 // Theme Helper Functions
 
-if (! function_exists('theme')) {
+if (!function_exists('theme')) {
     /**
      * Get the current active theme instance
      */
-    function theme(): \TallCms\Cms\Contracts\ThemeInterface
+    function theme(): ThemeInterface
     {
-        return \TallCms\Cms\Services\ThemeResolver::getCurrentTheme();
+        return ThemeResolver::getCurrentTheme();
     }
 }
 
-if (! function_exists('theme_colors')) {
+if (!function_exists('theme_colors')) {
     /**
      * Get the current theme's color palette
      *
@@ -125,7 +138,7 @@ if (! function_exists('theme_colors')) {
     }
 }
 
-if (! function_exists('theme_button_presets')) {
+if (!function_exists('theme_button_presets')) {
     /**
      * Get the current theme's button presets
      *
@@ -137,7 +150,7 @@ if (! function_exists('theme_button_presets')) {
     }
 }
 
-if (! function_exists('theme_text_presets')) {
+if (!function_exists('theme_text_presets')) {
     /**
      * Get the current theme's text presets
      *
@@ -148,8 +161,8 @@ if (! function_exists('theme_text_presets')) {
     function theme_text_presets(): array
     {
         // Graceful degradation for plugin mode without themes enabled
-        if (! app()->bound('theme.manager') ||
-            ! config('tallcms.plugin_mode.themes_enabled', true)) {
+        if (!app()->bound('theme.manager') ||
+            !config('tallcms.plugin_mode.themes_enabled', true)) {
             return [
                 'primary' => [
                     'heading' => '#111827',
@@ -164,7 +177,7 @@ if (! function_exists('theme_text_presets')) {
     }
 }
 
-if (! function_exists('theme_padding_presets')) {
+if (!function_exists('theme_padding_presets')) {
     /**
      * Get the current theme's padding presets
      *
@@ -178,27 +191,27 @@ if (! function_exists('theme_padding_presets')) {
 
 // Multi-Theme System Helper Functions
 
-if (! function_exists('theme_manager')) {
+if (!function_exists('theme_manager')) {
     /**
      * Get the theme manager instance
      */
-    function theme_manager(): \TallCms\Cms\Services\ThemeManager
+    function theme_manager(): ThemeManager
     {
-        return app(\TallCms\Cms\Services\ThemeManager::class);
+        return app(ThemeManager::class);
     }
 }
 
-if (! function_exists('active_theme')) {
+if (!function_exists('active_theme')) {
     /**
      * Get the active theme instance
      */
-    function active_theme(): ?\TallCms\Cms\Models\Theme
+    function active_theme(): ?Theme
     {
         return theme_manager()->getActiveTheme();
     }
 }
 
-if (! function_exists('daisyui_dark_preset')) {
+if (!function_exists('daisyui_dark_preset')) {
     /**
      * Get the DaisyUI preset that represents the "dark" option
      */
@@ -208,7 +221,7 @@ if (! function_exists('daisyui_dark_preset')) {
     }
 }
 
-if (! function_exists('daisyui_presets')) {
+if (!function_exists('daisyui_presets')) {
     /**
      * Get all available presets for theme-controller
      *
@@ -220,7 +233,7 @@ if (! function_exists('daisyui_presets')) {
     }
 }
 
-if (! function_exists('daisyui_default_preset')) {
+if (!function_exists('daisyui_default_preset')) {
     /**
      * Get the admin-configured default daisyUI preset for the active theme
      *
@@ -232,7 +245,7 @@ if (! function_exists('daisyui_default_preset')) {
         $theme = active_theme();
         $fallback = $theme?->getDaisyUIPreset() ?? 'light';
 
-        $stored = \TallCms\Cms\Models\SiteSetting::get('theme_default_preset');
+        $stored = SiteSetting::get('theme_default_preset');
         if ($stored && $stored !== '') {
             $available = $theme?->getDaisyUIPresets() ?? [];
             if (in_array($stored, $available, true)) {
@@ -244,7 +257,7 @@ if (! function_exists('daisyui_default_preset')) {
     }
 }
 
-if (! function_exists('supports_theme_controller')) {
+if (!function_exists('supports_theme_controller')) {
     /**
      * Check if theme supports runtime theme switching
      */
@@ -254,52 +267,52 @@ if (! function_exists('supports_theme_controller')) {
     }
 }
 
-if (! function_exists('tallcms_show_theme_switcher')) {
+if (!function_exists('tallcms_show_theme_switcher')) {
     function tallcms_show_theme_switcher(): bool
     {
-        if (! (active_theme()?->supportsThemeController() ?? false)) {
+        if (!(active_theme()?->supportsThemeController() ?? false)) {
             return false;
         }
 
-        return (bool) \TallCms\Cms\Models\SiteSetting::get('show_theme_switcher', true);
+        return (bool) SiteSetting::get('show_theme_switcher', true);
     }
 }
 
-if (! function_exists('tallcms_show_search')) {
+if (!function_exists('tallcms_show_search')) {
     function tallcms_show_search(): bool
     {
-        if (! (active_theme()?->supportsSearch() ?? false)) {
+        if (!(active_theme()?->supportsSearch() ?? false)) {
             return false;
         }
 
-        if (! config('tallcms.search.enabled', true)) {
+        if (!config('tallcms.search.enabled', true)) {
             return false;
         }
 
-        return (bool) \TallCms\Cms\Models\SiteSetting::get('show_search', true);
+        return (bool) SiteSetting::get('show_search', true);
     }
 }
 
-if (! function_exists('tallcms_show_language_dropdown')) {
+if (!function_exists('tallcms_show_language_dropdown')) {
     function tallcms_show_language_dropdown(): bool
     {
-        if (! (active_theme()?->supportsLanguageSwitcher() ?? false)) {
+        if (!(active_theme()?->supportsLanguageSwitcher() ?? false)) {
             return false;
         }
 
-        if (! tallcms_i18n_enabled()) {
+        if (!tallcms_i18n_enabled()) {
             return false;
         }
 
-        return (bool) \TallCms\Cms\Models\SiteSetting::get('show_language_dropdown', true);
+        return (bool) SiteSetting::get('show_language_dropdown', true);
     }
 }
 
-if (! function_exists('theme_asset')) {
+if (!function_exists('theme_asset')) {
     /**
      * Get theme asset URL with fallback
      *
-     * @param  string  $path  Path to the asset relative to theme's public directory
+     * @param string $path Path to the asset relative to theme's public directory
      * @return string The URL to the asset
      */
     function theme_asset(string $path): string
@@ -308,11 +321,11 @@ if (! function_exists('theme_asset')) {
     }
 }
 
-if (! function_exists('theme_vite_assets')) {
+if (!function_exists('theme_vite_assets')) {
     /**
      * Get theme Vite assets from manifest
      *
-     * @param  array<string>  $entrypoints  List of Vite entrypoints
+     * @param array<string> $entrypoints List of Vite entrypoints
      * @return array<string, string> Resolved asset URLs
      */
     function theme_vite_assets(array $entrypoints): array
@@ -321,11 +334,11 @@ if (! function_exists('theme_vite_assets')) {
     }
 }
 
-if (! function_exists('has_theme_override')) {
+if (!function_exists('has_theme_override')) {
     /**
      * Check if current theme has override for specific view
      *
-     * @param  string  $viewPath  Path to the view to check
+     * @param string $viewPath Path to the view to check
      * @return bool True if theme has an override
      */
     function has_theme_override(string $viewPath): bool
@@ -336,7 +349,7 @@ if (! function_exists('has_theme_override')) {
 
 // AWS / Storage Helper Functions
 
-if (! function_exists('cms_media_disk')) {
+if (!function_exists('cms_media_disk')) {
     /**
      * Get the disk name for CMS media uploads
      *
@@ -353,7 +366,7 @@ if (! function_exists('cms_media_disk')) {
     {
         // Explicit package-level override takes highest priority
         $configured = config('tallcms.media.disk');
-        if (! empty($configured)) {
+        if (!empty($configured)) {
             return $configured;
         }
 
@@ -365,7 +378,7 @@ if (! function_exists('cms_media_disk')) {
 
         // Fallback: check if S3 bucket is configured (supports IAM roles)
         $bucket = config('filesystems.disks.s3.bucket');
-        if (! empty($bucket)) {
+        if (!empty($bucket)) {
             return 's3';
         }
 
@@ -373,7 +386,7 @@ if (! function_exists('cms_media_disk')) {
     }
 }
 
-if (! function_exists('cms_media_visibility')) {
+if (!function_exists('cms_media_visibility')) {
     /**
      * Get the visibility setting for CMS media uploads
      *
@@ -385,7 +398,7 @@ if (! function_exists('cms_media_visibility')) {
     }
 }
 
-if (! function_exists('cms_uses_s3')) {
+if (!function_exists('cms_uses_s3')) {
     /**
      * Check if CMS is configured to use S3 for media storage
      *
@@ -402,7 +415,7 @@ if (! function_exists('cms_uses_s3')) {
 
 // Menu Helper Functions
 
-if (! function_exists('isMenuItemActive')) {
+if (!function_exists('isMenuItemActive')) {
     /**
      * Check if a menu item URL matches the current request
      */
@@ -444,24 +457,26 @@ if (! function_exists('isMenuItemActive')) {
     }
 }
 
-if (! function_exists('buildMenuItemArray')) {
+if (!function_exists('buildMenuItemArray')) {
     /**
      * Recursively build menu item array with children
      */
-    function buildMenuItemArray($item): array
+    function buildMenuItemArray($item, bool $resolveActiveState = true): array
     {
         $url = $item->getResolvedUrl();
-        $children = $item->children->map(function ($child) {
-            return buildMenuItemArray($child);
+        $children = $item->children->map(function ($child) use ($resolveActiveState) {
+            return buildMenuItemArray($child, $resolveActiveState);
         })->toArray();
 
         // Check if this item is active
-        $isActive = isMenuItemActive($url);
+        $isActive = $resolveActiveState ? isMenuItemActive($url) : false;
 
         // Check if any child is active (for parent highlighting)
-        $hasActiveChild = collect($children)->contains(function ($child) {
-            return $child['is_active'] || $child['has_active_child'];
-        });
+        $hasActiveChild = $resolveActiveState
+            ? collect($children)->contains(function ($child) {
+                return $child['is_active'] || $child['has_active_child'];
+            })
+            : false;
 
         return [
             'id' => $item->id,
@@ -478,33 +493,90 @@ if (! function_exists('buildMenuItemArray')) {
     }
 }
 
-if (! function_exists('menu')) {
+if (!function_exists('applyMenuActiveState')) {
+    /**
+     * Apply request-specific active state to a cached menu item array.
+     *
+     * @param array<string, mixed> $item
+     * @return array<string, mixed>
+     */
+    function applyMenuActiveState(array $item): array
+    {
+        $children = array_map(
+            fn (array $child): array => applyMenuActiveState($child),
+            $item['children'] ?? [],
+        );
+
+        $item['is_active'] = isMenuItemActive($item['url'] ?? null);
+        $item['has_active_child'] = collect($children)->contains(function (array $child): bool {
+            return ($child['is_active'] ?? false) || ($child['has_active_child'] ?? false);
+        });
+        $item['children'] = $children;
+
+        return $item;
+    }
+}
+
+if (!function_exists('menu')) {
     /**
      * Get a menu by location with resolved URLs
      */
     function menu(string $location): ?array
     {
-        $menu = \TallCms\Cms\Models\TallcmsMenu::byLocation($location);
+        $request = request();
 
-        if (! $menu) {
-            return null;
+        $cacheKey = implode('|', [
+            $location,
+            app()->getLocale(),
+            $request->getHost(),
+            $request->path(),
+        ]);
+
+        $resolvedMenus = $request->attributes->get('tallcms.resolved_menus', []);
+
+        if (array_key_exists($cacheKey, $resolvedMenus)) {
+            return $resolvedMenus[$cacheKey];
         }
 
-        // Get all menu items for this menu and build the tree structure
-        $items = $menu->allItems()
-            ->where('is_active', true)
-            ->with('page')
-            ->defaultOrder()
-            ->get()
-            ->toTree();
+        $persistentCacheKey = implode('|', [
+            'tallcms.menu',
+            $location,
+            app()->getLocale(),
+            $request->getHost(),
+        ]);
 
-        return $items->map(function ($item) {
-            return buildMenuItemArray($item);
-        })->toArray();
+        $cachedMenu = Cache::tags(['cms', 'cms:menus'])
+            ->remember($persistentCacheKey, now()->addHour(), function () use ($location): ?array {
+                $menu = TallcmsMenu::byLocation($location);
+
+                if (!$menu) {
+                    return null;
+                }
+
+                // Get all menu items for this menu and build the tree structure
+                $items = $menu->allItems()
+                    ->where('is_active', true)
+                    ->with('page')
+                    ->defaultOrder()
+                    ->get()
+                    ->toTree();
+
+                return $items->map(function ($item) {
+                    return buildMenuItemArray($item, false);
+                })->toArray();
+            });
+
+        $resolvedMenus[$cacheKey] = $cachedMenu === null
+            ? null
+            : array_map(fn (array $item): array => applyMenuActiveState($item), $cachedMenu);
+
+        $request->attributes->set('tallcms.resolved_menus', $resolvedMenus);
+
+        return $resolvedMenus[$cacheKey];
     }
 }
 
-if (! function_exists('render_menu')) {
+if (!function_exists('render_menu')) {
     /**
      * Render a menu as HTML
      */
@@ -512,7 +584,7 @@ if (! function_exists('render_menu')) {
     {
         $menu = menu($location);
 
-        if (! $menu) {
+        if (!$menu) {
             return '';
         }
 
@@ -532,13 +604,13 @@ if (! function_exists('render_menu')) {
     }
 }
 
-if (! function_exists('render_menu_item')) {
+if (!function_exists('render_menu_item')) {
     /**
      * Render a single menu item
      */
     function render_menu_item(array $item, string $liClass = '', string $linkClass = ''): string
     {
-        $hasChildren = ! empty($item['children']);
+        $hasChildren = !empty($item['children']);
         $liClass = trim($liClass.($hasChildren ? ' has-children' : ''));
 
         if ($item['css_class']) {
@@ -575,29 +647,29 @@ if (! function_exists('render_menu_item')) {
 
 // Plugin License Helper Functions
 
-if (! function_exists('plugin_is_licensed')) {
+if (!function_exists('plugin_is_licensed')) {
     /**
      * Check if a plugin has a valid license
      *
      * This performs the full license validation check (database + API if needed).
      * Use this for gating premium features.
      *
-     * @param  string  $pluginSlug  The plugin's license slug (e.g., 'tallcms-pro')
+     * @param string $pluginSlug The plugin's license slug (e.g., 'tallcms-pro')
      * @return bool True if the plugin has a valid license
      */
     function plugin_is_licensed(string $pluginSlug): bool
     {
         try {
-            $licenseService = app(\TallCms\Cms\Services\PluginLicenseService::class);
+            $licenseService = app(PluginLicenseService::class);
 
             return $licenseService->isValid($pluginSlug);
-        } catch (\Throwable) {
+        } catch (Throwable) {
             return false;
         }
     }
 }
 
-if (! function_exists('plugin_has_been_licensed')) {
+if (!function_exists('plugin_has_been_licensed')) {
     /**
      * Check if a plugin has ever been licensed (for watermark logic)
      *
@@ -607,16 +679,16 @@ if (! function_exists('plugin_has_been_licensed')) {
      *
      * Note: Returns false after license deactivation (user transferred license).
      *
-     * @param  string  $pluginSlug  The plugin's license slug (e.g., 'tallcms-pro')
+     * @param string $pluginSlug The plugin's license slug (e.g., 'tallcms-pro')
      * @return bool True if the plugin has ever been licensed
      */
     function plugin_has_been_licensed(string $pluginSlug): bool
     {
         try {
-            $licenseService = app(\TallCms\Cms\Services\PluginLicenseService::class);
+            $licenseService = app(PluginLicenseService::class);
 
             return $licenseService->hasEverBeenLicensed($pluginSlug);
-        } catch (\Throwable) {
+        } catch (Throwable) {
             return false;
         }
     }
@@ -624,7 +696,7 @@ if (! function_exists('plugin_has_been_licensed')) {
 
 // CMS Content Helper Functions
 
-if (! function_exists('cms_post_url')) {
+if (!function_exists('cms_post_url')) {
     /**
      * Generate URL for a post within a parent page context
      *
@@ -633,11 +705,11 @@ if (! function_exists('cms_post_url')) {
      * - Routes prefix in plugin mode
      * - Locale prefix when url_strategy is 'prefix'
      *
-     * @param  \TallCms\Cms\Models\CmsPost  $post  The post to generate URL for
-     * @param  string  $parentSlug  The parent page slug (e.g., 'blog')
+     * @param CmsPost $post The post to generate URL for
+     * @param string $parentSlug The parent page slug (e.g., 'blog')
      * @return string The full URL to the post
      */
-    function cms_post_url(\TallCms\Cms\Models\CmsPost $post, string $parentSlug): string
+    function cms_post_url(CmsPost $post, string $parentSlug): string
     {
         // Get the localized post slug
         $postSlug = tallcms_i18n_enabled()
@@ -652,7 +724,7 @@ if (! function_exists('cms_post_url')) {
 
 // SPA Mode Helper Functions
 
-if (! function_exists('tallcms_slug_to_anchor')) {
+if (!function_exists('tallcms_slug_to_anchor')) {
     /**
      * Convert a page slug to a valid HTML anchor ID for SPA mode.
      * Replaces slashes with hyphens and appends page ID for uniqueness.
@@ -666,8 +738,8 @@ if (! function_exists('tallcms_slug_to_anchor')) {
      * pages have similar slugs (e.g., 'services' and 'about/services').
      * Any manually created anchor links in content must use this format.
      *
-     * @param  string  $slug  The page slug (e.g., 'about/team')
-     * @param  int  $pageId  The page ID for collision prevention
+     * @param string $slug The page slug (e.g., 'about/team')
+     * @param int $pageId The page ID for collision prevention
      * @return string Valid anchor ID (e.g., 'about-team-42')
      */
     function tallcms_slug_to_anchor(string $slug, int $pageId): string
@@ -678,13 +750,13 @@ if (! function_exists('tallcms_slug_to_anchor')) {
 
 // Internationalization (i18n) Helper Functions
 
-if (! function_exists('tallcms_i18n_config')) {
+if (!function_exists('tallcms_i18n_config')) {
     /**
      * Get i18n config value, checking SiteSetting first, then config.
      * This bridges admin UI settings to runtime configuration.
      *
-     * @param  string  $key  Config key (e.g., 'enabled', 'default_locale')
-     * @param  mixed  $default  Default value if not found
+     * @param string $key Config key (e.g., 'enabled', 'default_locale')
+     * @param mixed $default Default value if not found
      * @return mixed The config value
      */
     function tallcms_i18n_config(string $key, mixed $default = null): mixed
@@ -700,12 +772,12 @@ if (! function_exists('tallcms_i18n_config')) {
             $settingKey = $settingMap[$key];
             // Wrap in try-catch for when table doesn't exist (e.g., during tests)
             try {
-                $dbValue = \TallCms\Cms\Models\SiteSetting::get($settingKey);
+                $dbValue = SiteSetting::get($settingKey);
 
                 if ($dbValue !== null) {
                     return $dbValue;
                 }
-            } catch (\Throwable) {
+            } catch (Throwable) {
                 // Table doesn't exist yet, fall through to config
             }
         }
@@ -715,7 +787,7 @@ if (! function_exists('tallcms_i18n_config')) {
     }
 }
 
-if (! function_exists('tallcms_localized_url')) {
+if (!function_exists('tallcms_localized_url')) {
     /**
      * Generate a locale-aware URL.
      * - prefix strategy: /es-MX/about (BCP-47 format in path)
@@ -729,13 +801,13 @@ if (! function_exists('tallcms_localized_url')) {
      * will result in double-prefixing. Use validation rules (UniqueTranslatableSlug, reserved
      * slugs) to prevent slugs that conflict with locale codes.
      *
-     * @param  string  $slug  The page/post slug (clean, without prefixes)
-     * @param  string|null  $locale  Internal locale code (es_mx). Uses current if null.
+     * @param string $slug The page/post slug (clean, without prefixes)
+     * @param string|null $locale Internal locale code (es_mx). Uses current if null.
      * @return string Full URL with locale indicator
      */
     function tallcms_localized_url(string $slug, ?string $locale = null): string
     {
-        $registry = app(\TallCms\Cms\Services\LocaleRegistry::class);
+        $registry = app(LocaleRegistry::class);
         $locale = $locale ?? app()->getLocale();
         $default = $registry->getDefaultLocale();
         $hideDefault = tallcms_i18n_config('hide_default_locale', true);
@@ -750,7 +822,7 @@ if (! function_exists('tallcms_localized_url')) {
         $baseSlug = $slug === '' ? '' : '/'.$slug;
 
         // If i18n disabled, return simple URL with routes prefix
-        if (! tallcms_i18n_config('enabled', false)) {
+        if (!tallcms_i18n_config('enabled', false)) {
             return $routesPrefix.($baseSlug ?: '/');
         }
 
@@ -762,16 +834,16 @@ if (! function_exists('tallcms_localized_url')) {
                 return $baseUrl;
             }
             // Append ?lang= with BCP-47 format
-            $bcp47 = \TallCms\Cms\Services\LocaleRegistry::toBcp47($locale);
+            $bcp47 = LocaleRegistry::toBcp47($locale);
 
             return $baseUrl.'?lang='.$bcp47;
         }
 
         // Strategy: 'prefix' - use path prefix
         $localePrefix = '';
-        if (! $hideDefault || $locale !== $default) {
+        if (!$hideDefault || $locale !== $default) {
             // Convert internal format (es_mx) to BCP-47 (es-MX) for URL
-            $localePrefix = '/'.\TallCms\Cms\Services\LocaleRegistry::toBcp47($locale);
+            $localePrefix = '/'.LocaleRegistry::toBcp47($locale);
         }
 
         // Build URL: routes_prefix + locale_prefix + slug
@@ -781,7 +853,7 @@ if (! function_exists('tallcms_localized_url')) {
     }
 }
 
-if (! function_exists('tallcms_resolve_custom_url')) {
+if (!function_exists('tallcms_resolve_custom_url')) {
     /**
      * Resolve a custom URL, handling both clean slugs and already-prefixed paths.
      *
@@ -795,7 +867,7 @@ if (! function_exists('tallcms_resolve_custom_url')) {
      *
      * Paths missing required prefixes are normalized through tallcms_localized_url().
      *
-     * @param  string  $url  The custom URL or slug
+     * @param string $url The custom URL or slug
      * @return string Resolved URL
      */
     function tallcms_resolve_custom_url(string $url): string
@@ -833,16 +905,16 @@ if (! function_exists('tallcms_resolve_custom_url')) {
 
             // Step 2: Check for locale prefix (after routes_prefix if present, or at start)
             if ($i18nEnabled && $urlStrategy === 'prefix') {
-                $registry = app(\TallCms\Cms\Services\LocaleRegistry::class);
+                $registry = app(LocaleRegistry::class);
                 $pathToCheck = $slugAfterPrefixes;
 
                 // Also check original path for locale-only URLs like /zh-CN/page
-                if (! $hasRoutesPrefix) {
+                if (!$hasRoutesPrefix) {
                     $pathToCheck = $pathWithoutSlash;
                 }
 
                 foreach ($registry->getLocaleCodes() as $localeCode) {
-                    $bcp47 = \TallCms\Cms\Services\LocaleRegistry::toBcp47($localeCode);
+                    $bcp47 = LocaleRegistry::toBcp47($localeCode);
                     if (str_starts_with($pathToCheck, $bcp47.'/')) {
                         $hasLocalePrefix = true;
                         $foundLocale = $localeCode;
@@ -858,8 +930,8 @@ if (! function_exists('tallcms_resolve_custom_url')) {
             }
 
             // Determine what's required
-            $needsRoutesPrefix = ! empty($routesPrefix);
-            $registry = $i18nEnabled ? app(\TallCms\Cms\Services\LocaleRegistry::class) : null;
+            $needsRoutesPrefix = !empty($routesPrefix);
+            $registry = $i18nEnabled ? app(LocaleRegistry::class) : null;
             $defaultLocale = $registry?->getDefaultLocale();
 
             // Special case: hide_default_locale=true and URL has default locale prefix
@@ -870,13 +942,13 @@ if (! function_exists('tallcms_resolve_custom_url')) {
             }
 
             // For non-default locales, locale prefix is always needed when i18n prefix strategy is active
-            $needsLocalePrefix = $i18nEnabled && $urlStrategy === 'prefix' && ! $hideDefault;
+            $needsLocalePrefix = $i18nEnabled && $urlStrategy === 'prefix' && !$hideDefault;
 
             // Case 1: Fully qualified (has all required prefixes)
             // For non-default locales with hide_default_locale=true, having locale prefix is correct
             if ($hasLocalePrefix && $foundLocale !== $defaultLocale) {
                 // Non-default locale with prefix - check routes_prefix requirement
-                if ($hasRoutesPrefix || ! $needsRoutesPrefix) {
+                if ($hasRoutesPrefix || !$needsRoutesPrefix) {
                     return $url;
                 }
 
@@ -885,18 +957,18 @@ if (! function_exists('tallcms_resolve_custom_url')) {
             }
 
             // Case 2: No locale prefix and no routes prefix requirement issue
-            if ((! $hasLocalePrefix || ! $needsLocalePrefix) &&
-                ($hasRoutesPrefix || ! $needsRoutesPrefix)) {
+            if ((!$hasLocalePrefix || !$needsLocalePrefix) &&
+                ($hasRoutesPrefix || !$needsRoutesPrefix)) {
                 return $url;
             }
 
             // Case 3: Has locale but missing routes_prefix
-            if ($hasLocalePrefix && $needsRoutesPrefix && ! $hasRoutesPrefix) {
+            if ($hasLocalePrefix && $needsRoutesPrefix && !$hasRoutesPrefix) {
                 return tallcms_localized_url($slugAfterPrefixes, $foundLocale);
             }
 
             // Case 4: Has routes_prefix but missing required locale
-            if ($hasRoutesPrefix && $needsLocalePrefix && ! $hasLocalePrefix) {
+            if ($hasRoutesPrefix && $needsLocalePrefix && !$hasLocalePrefix) {
                 return tallcms_localized_url($slugAfterPrefixes);
             }
 
@@ -909,17 +981,17 @@ if (! function_exists('tallcms_resolve_custom_url')) {
     }
 }
 
-if (! function_exists('tallcms_alternate_urls')) {
+if (!function_exists('tallcms_alternate_urls')) {
     /**
      * Get alternate URLs for all translations of a model.
      * Returns array keyed by internal locale code with BCP-47 formatted URLs.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model  Model with HasTranslatableContent
+     * @param Model $model Model with HasTranslatableContent
      * @return array<string, string> [locale => url]
      */
     function tallcms_alternate_urls($model): array
     {
-        $registry = app(\TallCms\Cms\Services\LocaleRegistry::class);
+        $registry = app(LocaleRegistry::class);
         $urls = [];
 
         foreach ($registry->getLocaleCodes() as $locale) {
@@ -934,7 +1006,7 @@ if (! function_exists('tallcms_alternate_urls')) {
     }
 }
 
-if (! function_exists('tallcms_current_locale')) {
+if (!function_exists('tallcms_current_locale')) {
     /**
      * Get current locale with i18n awareness.
      * Returns the app locale, which is set by SetLocaleMiddleware.
@@ -947,7 +1019,7 @@ if (! function_exists('tallcms_current_locale')) {
     }
 }
 
-if (! function_exists('tallcms_i18n_enabled')) {
+if (!function_exists('tallcms_i18n_enabled')) {
     /**
      * Check if i18n is enabled.
      *
@@ -959,7 +1031,7 @@ if (! function_exists('tallcms_i18n_enabled')) {
     }
 }
 
-if (! function_exists('tallcms_search_url')) {
+if (!function_exists('tallcms_search_url')) {
     /**
      * Get the search page URL respecting i18n and plugin mode prefixes.
      *
@@ -985,14 +1057,14 @@ if (! function_exists('tallcms_search_url')) {
 
         // Add locale prefix if i18n is enabled with prefix strategy
         if (tallcms_i18n_enabled() && $urlStrategy === 'prefix') {
-            $registry = app(\TallCms\Cms\Services\LocaleRegistry::class);
+            $registry = app(LocaleRegistry::class);
             $currentLocale = tallcms_current_locale();
             $defaultLocale = $registry->getDefaultLocale();
             $hideDefault = config('tallcms.i18n.hide_default_locale', true);
 
             // Add locale prefix unless it's hidden default
-            if (! ($hideDefault && $currentLocale === $defaultLocale)) {
-                $segments[] = \TallCms\Cms\Services\LocaleRegistry::toBcp47($currentLocale);
+            if (!($hideDefault && $currentLocale === $defaultLocale)) {
+                $segments[] = LocaleRegistry::toBcp47($currentLocale);
             }
         }
 
@@ -1002,14 +1074,14 @@ if (! function_exists('tallcms_search_url')) {
 
         // For 'none' strategy, append ?lang= query parameter
         if (tallcms_i18n_enabled() && $urlStrategy === 'none') {
-            $registry = app(\TallCms\Cms\Services\LocaleRegistry::class);
+            $registry = app(LocaleRegistry::class);
             $currentLocale = tallcms_current_locale();
             $defaultLocale = $registry->getDefaultLocale();
             $hideDefault = config('tallcms.i18n.hide_default_locale', true);
 
             // Append ?lang= unless it's hidden default
-            if (! ($hideDefault && $currentLocale === $defaultLocale)) {
-                $bcp47 = \TallCms\Cms\Services\LocaleRegistry::toBcp47($currentLocale);
+            if (!($hideDefault && $currentLocale === $defaultLocale)) {
+                $bcp47 = LocaleRegistry::toBcp47($currentLocale);
 
                 return $baseUrl.'?lang='.$bcp47;
             }
@@ -1019,7 +1091,7 @@ if (! function_exists('tallcms_search_url')) {
     }
 }
 
-if (! function_exists('tallcms_current_slug')) {
+if (!function_exists('tallcms_current_slug')) {
     /**
      * Extract the clean content slug from the current request path.
      *
@@ -1053,9 +1125,9 @@ if (! function_exists('tallcms_current_slug')) {
 
         // Strip locale prefix if i18n is enabled with prefix strategy
         if (tallcms_i18n_config('enabled', false) && config('tallcms.i18n.url_strategy', 'prefix') === 'prefix') {
-            $registry = app(\TallCms\Cms\Services\LocaleRegistry::class);
+            $registry = app(LocaleRegistry::class);
             foreach ($registry->getLocaleCodes() as $localeCode) {
-                $bcp47 = \TallCms\Cms\Services\LocaleRegistry::toBcp47($localeCode);
+                $bcp47 = LocaleRegistry::toBcp47($localeCode);
                 if (str_starts_with($path, $bcp47.'/')) {
                     $path = substr($path, strlen($bcp47) + 1);
                     break;
@@ -1069,18 +1141,18 @@ if (! function_exists('tallcms_current_slug')) {
     }
 }
 
-if (! function_exists('tallcms_locale_label')) {
+if (!function_exists('tallcms_locale_label')) {
     /**
      * Get the display label (native name) for a locale code.
      *
-     * @param  string  $localeCode  The locale code (internal or BCP-47 format)
-     * @param  bool  $native  Whether to return native name (true) or English label (false)
+     * @param string $localeCode The locale code (internal or BCP-47 format)
+     * @param bool $native Whether to return native name (true) or English label (false)
      * @return string The locale label, or the code itself if not found
      */
     function tallcms_locale_label(string $localeCode, bool $native = true): string
     {
-        $registry = app(\TallCms\Cms\Services\LocaleRegistry::class);
-        $normalized = \TallCms\Cms\Services\LocaleRegistry::normalizeLocaleCode($localeCode);
+        $registry = app(LocaleRegistry::class);
+        $normalized = LocaleRegistry::normalizeLocaleCode($localeCode);
         $locales = $registry->getLocales();
 
         if (isset($locales[$normalized])) {
@@ -1093,7 +1165,7 @@ if (! function_exists('tallcms_locale_label')) {
     }
 }
 
-if (! function_exists('tallcms_review_workflow_enabled')) {
+if (!function_exists('tallcms_review_workflow_enabled')) {
     /**
      * Check if the review workflow is enabled for the current site.
      *
@@ -1113,14 +1185,14 @@ if (! function_exists('tallcms_review_workflow_enabled')) {
         $multisiteActive = false;
         try {
             if (class_exists('Tallcms\Multisite\Scopes\SiteScope')) {
-                $multisiteActive = \TallCms\Cms\Models\CmsPage::hasGlobalScope('Tallcms\Multisite\Scopes\SiteScope');
+                $multisiteActive = CmsPage::hasGlobalScope('Tallcms\Multisite\Scopes\SiteScope');
             }
-        } catch (\Throwable) {
+        } catch (Throwable) {
         }
-        $default = ! $multisiteActive;
+        $default = !$multisiteActive;
 
         try {
-            $value = \TallCms\Cms\Models\SiteSetting::get('review_workflow_enabled');
+            $value = SiteSetting::get('review_workflow_enabled');
 
             // If not explicitly set, use the default
             if ($value === null || $value === '') {
@@ -1128,13 +1200,13 @@ if (! function_exists('tallcms_review_workflow_enabled')) {
             }
 
             return filter_var($value, FILTER_VALIDATE_BOOLEAN);
-        } catch (\Throwable) {
+        } catch (Throwable) {
             return $default;
         }
     }
 }
 
-if (! function_exists('tallcms_base_url')) {
+if (!function_exists('tallcms_base_url')) {
     /**
      * Get the canonical base URL for the current site context.
      *
@@ -1147,7 +1219,7 @@ if (! function_exists('tallcms_base_url')) {
         // Explicit site_id: look up the domain directly
         if ($siteId !== null) {
             try {
-                $domain = \Illuminate\Support\Facades\DB::table('tallcms_sites')
+                $domain = DB::table('tallcms_sites')
                     ->where('id', $siteId)
                     ->value('domain');
 
@@ -1157,7 +1229,7 @@ if (! function_exists('tallcms_base_url')) {
 
                     return "{$scheme}://{$domain}";
                 }
-            } catch (\Throwable) {
+            } catch (Throwable) {
             }
         }
 
@@ -1171,7 +1243,7 @@ if (! function_exists('tallcms_base_url')) {
     }
 }
 
-if (! function_exists('tallcms_multisite_active')) {
+if (!function_exists('tallcms_multisite_active')) {
     /**
      * Check if the multisite plugin is actively running.
      *
@@ -1183,9 +1255,9 @@ if (! function_exists('tallcms_multisite_active')) {
     {
         try {
             if (class_exists('Tallcms\Multisite\Scopes\SiteScope')) {
-                return \TallCms\Cms\Models\CmsPage::hasGlobalScope('Tallcms\Multisite\Scopes\SiteScope');
+                return CmsPage::hasGlobalScope('Tallcms\Multisite\Scopes\SiteScope');
             }
-        } catch (\Throwable) {
+        } catch (Throwable) {
         }
 
         return false;

--- a/packages/tallcms/cms/src/helpers.php
+++ b/packages/tallcms/cms/src/helpers.php
@@ -1,19 +1,6 @@
 <?php
 
 declare(strict_types=1);
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\DB;
-use TallCms\Cms\Contracts\ThemeInterface;
-use TallCms\Cms\Models\CmsPage;
-use TallCms\Cms\Models\CmsPost;
-use TallCms\Cms\Models\SiteSetting;
-use TallCms\Cms\Models\TallcmsMenu;
-use TallCms\Cms\Models\Theme;
-use TallCms\Cms\Services\LocaleRegistry;
-use TallCms\Cms\Services\PluginLicenseService;
-use TallCms\Cms\Services\ThemeManager;
-use TallCms\Cms\Services\ThemeResolver;
-use TallCms\Cms\Support\MenuCache;
 
 /**
  * TallCMS Helper Functions
@@ -27,7 +14,7 @@ use TallCms\Cms\Support\MenuCache;
 
 // URL Helper Functions
 
-if (!function_exists('tallcms_routes_prefix')) {
+if (! function_exists('tallcms_routes_prefix')) {
     /**
      * Get the configured routes prefix for CMS frontend routes
      *
@@ -42,7 +29,7 @@ if (!function_exists('tallcms_routes_prefix')) {
     }
 }
 
-if (!function_exists('tallcms_home_url')) {
+if (! function_exists('tallcms_home_url')) {
     /**
      * Get the CMS homepage URL, respecting routes prefix
      *
@@ -56,11 +43,11 @@ if (!function_exists('tallcms_home_url')) {
     }
 }
 
-if (!function_exists('tallcms_page_url')) {
+if (! function_exists('tallcms_page_url')) {
     /**
      * Get a CMS page URL by slug, respecting routes prefix
      *
-     * @param string $slug The page slug (with or without leading slash)
+     * @param  string  $slug  The page slug (with or without leading slash)
      * @return string The full URL to the page
      */
     function tallcms_page_url(string $slug): string
@@ -77,11 +64,11 @@ if (!function_exists('tallcms_page_url')) {
 
 // Filament Panel Helper Functions
 
-if (!function_exists('tallcms_panel_url')) {
+if (! function_exists('tallcms_panel_url')) {
     /**
      * Get the full URL to the Filament admin panel, optionally with a sub-path.
      *
-     * @param string $path Optional sub-path to append (e.g., 'cms-pages/create')
+     * @param  string  $path  Optional sub-path to append (e.g., 'cms-pages/create')
      * @return string The full URL to the panel
      */
     function tallcms_panel_url(string $path = ''): string
@@ -98,12 +85,12 @@ if (!function_exists('tallcms_panel_url')) {
     }
 }
 
-if (!function_exists('tallcms_panel_route')) {
+if (! function_exists('tallcms_panel_route')) {
     /**
      * Build a Filament route name dynamically using the configured panel ID.
      *
-     * @param string $suffix The route suffix (e.g., 'pages.plugin-licenses')
-     * @param mixed $parameters Optional route parameters
+     * @param  string  $suffix  The route suffix (e.g., 'pages.plugin-licenses')
+     * @param  mixed  $parameters  Optional route parameters
      * @return string The resolved route URL
      */
     function tallcms_panel_route(string $suffix, mixed $parameters = []): string
@@ -116,17 +103,17 @@ if (!function_exists('tallcms_panel_route')) {
 
 // Theme Helper Functions
 
-if (!function_exists('theme')) {
+if (! function_exists('theme')) {
     /**
      * Get the current active theme instance
      */
-    function theme(): ThemeInterface
+    function theme(): \TallCms\Cms\Contracts\ThemeInterface
     {
-        return ThemeResolver::getCurrentTheme();
+        return \TallCms\Cms\Services\ThemeResolver::getCurrentTheme();
     }
 }
 
-if (!function_exists('theme_colors')) {
+if (! function_exists('theme_colors')) {
     /**
      * Get the current theme's color palette
      *
@@ -138,7 +125,7 @@ if (!function_exists('theme_colors')) {
     }
 }
 
-if (!function_exists('theme_button_presets')) {
+if (! function_exists('theme_button_presets')) {
     /**
      * Get the current theme's button presets
      *
@@ -150,7 +137,7 @@ if (!function_exists('theme_button_presets')) {
     }
 }
 
-if (!function_exists('theme_text_presets')) {
+if (! function_exists('theme_text_presets')) {
     /**
      * Get the current theme's text presets
      *
@@ -161,8 +148,8 @@ if (!function_exists('theme_text_presets')) {
     function theme_text_presets(): array
     {
         // Graceful degradation for plugin mode without themes enabled
-        if (!app()->bound('theme.manager') ||
-            !config('tallcms.plugin_mode.themes_enabled', true)) {
+        if (! app()->bound('theme.manager') ||
+            ! config('tallcms.plugin_mode.themes_enabled', true)) {
             return [
                 'primary' => [
                     'heading' => '#111827',
@@ -177,7 +164,7 @@ if (!function_exists('theme_text_presets')) {
     }
 }
 
-if (!function_exists('theme_padding_presets')) {
+if (! function_exists('theme_padding_presets')) {
     /**
      * Get the current theme's padding presets
      *
@@ -191,27 +178,27 @@ if (!function_exists('theme_padding_presets')) {
 
 // Multi-Theme System Helper Functions
 
-if (!function_exists('theme_manager')) {
+if (! function_exists('theme_manager')) {
     /**
      * Get the theme manager instance
      */
-    function theme_manager(): ThemeManager
+    function theme_manager(): \TallCms\Cms\Services\ThemeManager
     {
-        return app(ThemeManager::class);
+        return app(\TallCms\Cms\Services\ThemeManager::class);
     }
 }
 
-if (!function_exists('active_theme')) {
+if (! function_exists('active_theme')) {
     /**
      * Get the active theme instance
      */
-    function active_theme(): ?Theme
+    function active_theme(): ?\TallCms\Cms\Models\Theme
     {
         return theme_manager()->getActiveTheme();
     }
 }
 
-if (!function_exists('daisyui_dark_preset')) {
+if (! function_exists('daisyui_dark_preset')) {
     /**
      * Get the DaisyUI preset that represents the "dark" option
      */
@@ -221,7 +208,7 @@ if (!function_exists('daisyui_dark_preset')) {
     }
 }
 
-if (!function_exists('daisyui_presets')) {
+if (! function_exists('daisyui_presets')) {
     /**
      * Get all available presets for theme-controller
      *
@@ -233,7 +220,7 @@ if (!function_exists('daisyui_presets')) {
     }
 }
 
-if (!function_exists('daisyui_default_preset')) {
+if (! function_exists('daisyui_default_preset')) {
     /**
      * Get the admin-configured default daisyUI preset for the active theme
      *
@@ -245,7 +232,7 @@ if (!function_exists('daisyui_default_preset')) {
         $theme = active_theme();
         $fallback = $theme?->getDaisyUIPreset() ?? 'light';
 
-        $stored = SiteSetting::get('theme_default_preset');
+        $stored = \TallCms\Cms\Models\SiteSetting::get('theme_default_preset');
         if ($stored && $stored !== '') {
             $available = $theme?->getDaisyUIPresets() ?? [];
             if (in_array($stored, $available, true)) {
@@ -257,7 +244,7 @@ if (!function_exists('daisyui_default_preset')) {
     }
 }
 
-if (!function_exists('supports_theme_controller')) {
+if (! function_exists('supports_theme_controller')) {
     /**
      * Check if theme supports runtime theme switching
      */
@@ -267,52 +254,52 @@ if (!function_exists('supports_theme_controller')) {
     }
 }
 
-if (!function_exists('tallcms_show_theme_switcher')) {
+if (! function_exists('tallcms_show_theme_switcher')) {
     function tallcms_show_theme_switcher(): bool
     {
-        if (!(active_theme()?->supportsThemeController() ?? false)) {
+        if (! (active_theme()?->supportsThemeController() ?? false)) {
             return false;
         }
 
-        return (bool) SiteSetting::get('show_theme_switcher', true);
+        return (bool) \TallCms\Cms\Models\SiteSetting::get('show_theme_switcher', true);
     }
 }
 
-if (!function_exists('tallcms_show_search')) {
+if (! function_exists('tallcms_show_search')) {
     function tallcms_show_search(): bool
     {
-        if (!(active_theme()?->supportsSearch() ?? false)) {
+        if (! (active_theme()?->supportsSearch() ?? false)) {
             return false;
         }
 
-        if (!config('tallcms.search.enabled', true)) {
+        if (! config('tallcms.search.enabled', true)) {
             return false;
         }
 
-        return (bool) SiteSetting::get('show_search', true);
+        return (bool) \TallCms\Cms\Models\SiteSetting::get('show_search', true);
     }
 }
 
-if (!function_exists('tallcms_show_language_dropdown')) {
+if (! function_exists('tallcms_show_language_dropdown')) {
     function tallcms_show_language_dropdown(): bool
     {
-        if (!(active_theme()?->supportsLanguageSwitcher() ?? false)) {
+        if (! (active_theme()?->supportsLanguageSwitcher() ?? false)) {
             return false;
         }
 
-        if (!tallcms_i18n_enabled()) {
+        if (! tallcms_i18n_enabled()) {
             return false;
         }
 
-        return (bool) SiteSetting::get('show_language_dropdown', true);
+        return (bool) \TallCms\Cms\Models\SiteSetting::get('show_language_dropdown', true);
     }
 }
 
-if (!function_exists('theme_asset')) {
+if (! function_exists('theme_asset')) {
     /**
      * Get theme asset URL with fallback
      *
-     * @param string $path Path to the asset relative to theme's public directory
+     * @param  string  $path  Path to the asset relative to theme's public directory
      * @return string The URL to the asset
      */
     function theme_asset(string $path): string
@@ -321,11 +308,11 @@ if (!function_exists('theme_asset')) {
     }
 }
 
-if (!function_exists('theme_vite_assets')) {
+if (! function_exists('theme_vite_assets')) {
     /**
      * Get theme Vite assets from manifest
      *
-     * @param array<string> $entrypoints List of Vite entrypoints
+     * @param  array<string>  $entrypoints  List of Vite entrypoints
      * @return array<string, string> Resolved asset URLs
      */
     function theme_vite_assets(array $entrypoints): array
@@ -334,11 +321,11 @@ if (!function_exists('theme_vite_assets')) {
     }
 }
 
-if (!function_exists('has_theme_override')) {
+if (! function_exists('has_theme_override')) {
     /**
      * Check if current theme has override for specific view
      *
-     * @param string $viewPath Path to the view to check
+     * @param  string  $viewPath  Path to the view to check
      * @return bool True if theme has an override
      */
     function has_theme_override(string $viewPath): bool
@@ -349,7 +336,7 @@ if (!function_exists('has_theme_override')) {
 
 // AWS / Storage Helper Functions
 
-if (!function_exists('cms_media_disk')) {
+if (! function_exists('cms_media_disk')) {
     /**
      * Get the disk name for CMS media uploads
      *
@@ -366,7 +353,7 @@ if (!function_exists('cms_media_disk')) {
     {
         // Explicit package-level override takes highest priority
         $configured = config('tallcms.media.disk');
-        if (!empty($configured)) {
+        if (! empty($configured)) {
             return $configured;
         }
 
@@ -378,7 +365,7 @@ if (!function_exists('cms_media_disk')) {
 
         // Fallback: check if S3 bucket is configured (supports IAM roles)
         $bucket = config('filesystems.disks.s3.bucket');
-        if (!empty($bucket)) {
+        if (! empty($bucket)) {
             return 's3';
         }
 
@@ -386,7 +373,7 @@ if (!function_exists('cms_media_disk')) {
     }
 }
 
-if (!function_exists('cms_media_visibility')) {
+if (! function_exists('cms_media_visibility')) {
     /**
      * Get the visibility setting for CMS media uploads
      *
@@ -398,7 +385,7 @@ if (!function_exists('cms_media_visibility')) {
     }
 }
 
-if (!function_exists('cms_uses_s3')) {
+if (! function_exists('cms_uses_s3')) {
     /**
      * Check if CMS is configured to use S3 for media storage
      *
@@ -415,7 +402,7 @@ if (!function_exists('cms_uses_s3')) {
 
 // Menu Helper Functions
 
-if (!function_exists('isMenuItemActive')) {
+if (! function_exists('isMenuItemActive')) {
     /**
      * Check if a menu item URL matches the current request
      */
@@ -457,7 +444,7 @@ if (!function_exists('isMenuItemActive')) {
     }
 }
 
-if (!function_exists('buildMenuItemArray')) {
+if (! function_exists('buildMenuItemArray')) {
     /**
      * Recursively build menu item array with children
      */
@@ -493,11 +480,11 @@ if (!function_exists('buildMenuItemArray')) {
     }
 }
 
-if (!function_exists('applyMenuActiveState')) {
+if (! function_exists('applyMenuActiveState')) {
     /**
      * Apply request-specific active state to a cached menu item array.
      *
-     * @param array<string, mixed> $item
+     * @param  array<string, mixed>  $item
      * @return array<string, mixed>
      */
     function applyMenuActiveState(array $item): array
@@ -517,7 +504,7 @@ if (!function_exists('applyMenuActiveState')) {
     }
 }
 
-if (!function_exists('menu')) {
+if (! function_exists('menu')) {
     /**
      * Get a menu by location with resolved URLs
      */
@@ -545,10 +532,10 @@ if (!function_exists('menu')) {
             $request->getHost(),
         ]);
 
-        $cachedMenu = MenuCache::remember($persistentCacheKey, now()->addHour(), function () use ($location): ?array {
-            $menu = TallcmsMenu::byLocation($location);
+        $cachedMenu = \TallCms\Cms\Support\MenuCache::remember($persistentCacheKey, now()->addHour(), function () use ($location): ?array {
+            $menu = \TallCms\Cms\Models\TallcmsMenu::byLocation($location);
 
-            if (!$menu) {
+            if (! $menu) {
                 return null;
             }
 
@@ -575,7 +562,7 @@ if (!function_exists('menu')) {
     }
 }
 
-if (!function_exists('render_menu')) {
+if (! function_exists('render_menu')) {
     /**
      * Render a menu as HTML
      */
@@ -583,7 +570,7 @@ if (!function_exists('render_menu')) {
     {
         $menu = menu($location);
 
-        if (!$menu) {
+        if (! $menu) {
             return '';
         }
 
@@ -603,13 +590,13 @@ if (!function_exists('render_menu')) {
     }
 }
 
-if (!function_exists('render_menu_item')) {
+if (! function_exists('render_menu_item')) {
     /**
      * Render a single menu item
      */
     function render_menu_item(array $item, string $liClass = '', string $linkClass = ''): string
     {
-        $hasChildren = !empty($item['children']);
+        $hasChildren = ! empty($item['children']);
         $liClass = trim($liClass.($hasChildren ? ' has-children' : ''));
 
         if ($item['css_class']) {
@@ -646,29 +633,29 @@ if (!function_exists('render_menu_item')) {
 
 // Plugin License Helper Functions
 
-if (!function_exists('plugin_is_licensed')) {
+if (! function_exists('plugin_is_licensed')) {
     /**
      * Check if a plugin has a valid license
      *
      * This performs the full license validation check (database + API if needed).
      * Use this for gating premium features.
      *
-     * @param string $pluginSlug The plugin's license slug (e.g., 'tallcms-pro')
+     * @param  string  $pluginSlug  The plugin's license slug (e.g., 'tallcms-pro')
      * @return bool True if the plugin has a valid license
      */
     function plugin_is_licensed(string $pluginSlug): bool
     {
         try {
-            $licenseService = app(PluginLicenseService::class);
+            $licenseService = app(\TallCms\Cms\Services\PluginLicenseService::class);
 
             return $licenseService->isValid($pluginSlug);
-        } catch (Throwable) {
+        } catch (\Throwable) {
             return false;
         }
     }
 }
 
-if (!function_exists('plugin_has_been_licensed')) {
+if (! function_exists('plugin_has_been_licensed')) {
     /**
      * Check if a plugin has ever been licensed (for watermark logic)
      *
@@ -678,16 +665,16 @@ if (!function_exists('plugin_has_been_licensed')) {
      *
      * Note: Returns false after license deactivation (user transferred license).
      *
-     * @param string $pluginSlug The plugin's license slug (e.g., 'tallcms-pro')
+     * @param  string  $pluginSlug  The plugin's license slug (e.g., 'tallcms-pro')
      * @return bool True if the plugin has ever been licensed
      */
     function plugin_has_been_licensed(string $pluginSlug): bool
     {
         try {
-            $licenseService = app(PluginLicenseService::class);
+            $licenseService = app(\TallCms\Cms\Services\PluginLicenseService::class);
 
             return $licenseService->hasEverBeenLicensed($pluginSlug);
-        } catch (Throwable) {
+        } catch (\Throwable) {
             return false;
         }
     }
@@ -695,7 +682,7 @@ if (!function_exists('plugin_has_been_licensed')) {
 
 // CMS Content Helper Functions
 
-if (!function_exists('cms_post_url')) {
+if (! function_exists('cms_post_url')) {
     /**
      * Generate URL for a post within a parent page context
      *
@@ -704,11 +691,11 @@ if (!function_exists('cms_post_url')) {
      * - Routes prefix in plugin mode
      * - Locale prefix when url_strategy is 'prefix'
      *
-     * @param CmsPost $post The post to generate URL for
-     * @param string $parentSlug The parent page slug (e.g., 'blog')
+     * @param  \TallCms\Cms\Models\CmsPost  $post  The post to generate URL for
+     * @param  string  $parentSlug  The parent page slug (e.g., 'blog')
      * @return string The full URL to the post
      */
-    function cms_post_url(CmsPost $post, string $parentSlug): string
+    function cms_post_url(\TallCms\Cms\Models\CmsPost $post, string $parentSlug): string
     {
         // Get the localized post slug
         $postSlug = tallcms_i18n_enabled()
@@ -723,7 +710,7 @@ if (!function_exists('cms_post_url')) {
 
 // SPA Mode Helper Functions
 
-if (!function_exists('tallcms_slug_to_anchor')) {
+if (! function_exists('tallcms_slug_to_anchor')) {
     /**
      * Convert a page slug to a valid HTML anchor ID for SPA mode.
      * Replaces slashes with hyphens and appends page ID for uniqueness.
@@ -737,8 +724,8 @@ if (!function_exists('tallcms_slug_to_anchor')) {
      * pages have similar slugs (e.g., 'services' and 'about/services').
      * Any manually created anchor links in content must use this format.
      *
-     * @param string $slug The page slug (e.g., 'about/team')
-     * @param int $pageId The page ID for collision prevention
+     * @param  string  $slug  The page slug (e.g., 'about/team')
+     * @param  int  $pageId  The page ID for collision prevention
      * @return string Valid anchor ID (e.g., 'about-team-42')
      */
     function tallcms_slug_to_anchor(string $slug, int $pageId): string
@@ -749,13 +736,13 @@ if (!function_exists('tallcms_slug_to_anchor')) {
 
 // Internationalization (i18n) Helper Functions
 
-if (!function_exists('tallcms_i18n_config')) {
+if (! function_exists('tallcms_i18n_config')) {
     /**
      * Get i18n config value, checking SiteSetting first, then config.
      * This bridges admin UI settings to runtime configuration.
      *
-     * @param string $key Config key (e.g., 'enabled', 'default_locale')
-     * @param mixed $default Default value if not found
+     * @param  string  $key  Config key (e.g., 'enabled', 'default_locale')
+     * @param  mixed  $default  Default value if not found
      * @return mixed The config value
      */
     function tallcms_i18n_config(string $key, mixed $default = null): mixed
@@ -771,12 +758,12 @@ if (!function_exists('tallcms_i18n_config')) {
             $settingKey = $settingMap[$key];
             // Wrap in try-catch for when table doesn't exist (e.g., during tests)
             try {
-                $dbValue = SiteSetting::get($settingKey);
+                $dbValue = \TallCms\Cms\Models\SiteSetting::get($settingKey);
 
                 if ($dbValue !== null) {
                     return $dbValue;
                 }
-            } catch (Throwable) {
+            } catch (\Throwable) {
                 // Table doesn't exist yet, fall through to config
             }
         }
@@ -786,7 +773,7 @@ if (!function_exists('tallcms_i18n_config')) {
     }
 }
 
-if (!function_exists('tallcms_localized_url')) {
+if (! function_exists('tallcms_localized_url')) {
     /**
      * Generate a locale-aware URL.
      * - prefix strategy: /es-MX/about (BCP-47 format in path)
@@ -800,13 +787,13 @@ if (!function_exists('tallcms_localized_url')) {
      * will result in double-prefixing. Use validation rules (UniqueTranslatableSlug, reserved
      * slugs) to prevent slugs that conflict with locale codes.
      *
-     * @param string $slug The page/post slug (clean, without prefixes)
-     * @param string|null $locale Internal locale code (es_mx). Uses current if null.
+     * @param  string  $slug  The page/post slug (clean, without prefixes)
+     * @param  string|null  $locale  Internal locale code (es_mx). Uses current if null.
      * @return string Full URL with locale indicator
      */
     function tallcms_localized_url(string $slug, ?string $locale = null): string
     {
-        $registry = app(LocaleRegistry::class);
+        $registry = app(\TallCms\Cms\Services\LocaleRegistry::class);
         $locale = $locale ?? app()->getLocale();
         $default = $registry->getDefaultLocale();
         $hideDefault = tallcms_i18n_config('hide_default_locale', true);
@@ -821,7 +808,7 @@ if (!function_exists('tallcms_localized_url')) {
         $baseSlug = $slug === '' ? '' : '/'.$slug;
 
         // If i18n disabled, return simple URL with routes prefix
-        if (!tallcms_i18n_config('enabled', false)) {
+        if (! tallcms_i18n_config('enabled', false)) {
             return $routesPrefix.($baseSlug ?: '/');
         }
 
@@ -833,16 +820,16 @@ if (!function_exists('tallcms_localized_url')) {
                 return $baseUrl;
             }
             // Append ?lang= with BCP-47 format
-            $bcp47 = LocaleRegistry::toBcp47($locale);
+            $bcp47 = \TallCms\Cms\Services\LocaleRegistry::toBcp47($locale);
 
             return $baseUrl.'?lang='.$bcp47;
         }
 
         // Strategy: 'prefix' - use path prefix
         $localePrefix = '';
-        if (!$hideDefault || $locale !== $default) {
+        if (! $hideDefault || $locale !== $default) {
             // Convert internal format (es_mx) to BCP-47 (es-MX) for URL
-            $localePrefix = '/'.LocaleRegistry::toBcp47($locale);
+            $localePrefix = '/'.\TallCms\Cms\Services\LocaleRegistry::toBcp47($locale);
         }
 
         // Build URL: routes_prefix + locale_prefix + slug
@@ -852,7 +839,7 @@ if (!function_exists('tallcms_localized_url')) {
     }
 }
 
-if (!function_exists('tallcms_resolve_custom_url')) {
+if (! function_exists('tallcms_resolve_custom_url')) {
     /**
      * Resolve a custom URL, handling both clean slugs and already-prefixed paths.
      *
@@ -866,7 +853,7 @@ if (!function_exists('tallcms_resolve_custom_url')) {
      *
      * Paths missing required prefixes are normalized through tallcms_localized_url().
      *
-     * @param string $url The custom URL or slug
+     * @param  string  $url  The custom URL or slug
      * @return string Resolved URL
      */
     function tallcms_resolve_custom_url(string $url): string
@@ -904,16 +891,16 @@ if (!function_exists('tallcms_resolve_custom_url')) {
 
             // Step 2: Check for locale prefix (after routes_prefix if present, or at start)
             if ($i18nEnabled && $urlStrategy === 'prefix') {
-                $registry = app(LocaleRegistry::class);
+                $registry = app(\TallCms\Cms\Services\LocaleRegistry::class);
                 $pathToCheck = $slugAfterPrefixes;
 
                 // Also check original path for locale-only URLs like /zh-CN/page
-                if (!$hasRoutesPrefix) {
+                if (! $hasRoutesPrefix) {
                     $pathToCheck = $pathWithoutSlash;
                 }
 
                 foreach ($registry->getLocaleCodes() as $localeCode) {
-                    $bcp47 = LocaleRegistry::toBcp47($localeCode);
+                    $bcp47 = \TallCms\Cms\Services\LocaleRegistry::toBcp47($localeCode);
                     if (str_starts_with($pathToCheck, $bcp47.'/')) {
                         $hasLocalePrefix = true;
                         $foundLocale = $localeCode;
@@ -929,8 +916,8 @@ if (!function_exists('tallcms_resolve_custom_url')) {
             }
 
             // Determine what's required
-            $needsRoutesPrefix = !empty($routesPrefix);
-            $registry = $i18nEnabled ? app(LocaleRegistry::class) : null;
+            $needsRoutesPrefix = ! empty($routesPrefix);
+            $registry = $i18nEnabled ? app(\TallCms\Cms\Services\LocaleRegistry::class) : null;
             $defaultLocale = $registry?->getDefaultLocale();
 
             // Special case: hide_default_locale=true and URL has default locale prefix
@@ -941,13 +928,13 @@ if (!function_exists('tallcms_resolve_custom_url')) {
             }
 
             // For non-default locales, locale prefix is always needed when i18n prefix strategy is active
-            $needsLocalePrefix = $i18nEnabled && $urlStrategy === 'prefix' && !$hideDefault;
+            $needsLocalePrefix = $i18nEnabled && $urlStrategy === 'prefix' && ! $hideDefault;
 
             // Case 1: Fully qualified (has all required prefixes)
             // For non-default locales with hide_default_locale=true, having locale prefix is correct
             if ($hasLocalePrefix && $foundLocale !== $defaultLocale) {
                 // Non-default locale with prefix - check routes_prefix requirement
-                if ($hasRoutesPrefix || !$needsRoutesPrefix) {
+                if ($hasRoutesPrefix || ! $needsRoutesPrefix) {
                     return $url;
                 }
 
@@ -956,18 +943,18 @@ if (!function_exists('tallcms_resolve_custom_url')) {
             }
 
             // Case 2: No locale prefix and no routes prefix requirement issue
-            if ((!$hasLocalePrefix || !$needsLocalePrefix) &&
-                ($hasRoutesPrefix || !$needsRoutesPrefix)) {
+            if ((! $hasLocalePrefix || ! $needsLocalePrefix) &&
+                ($hasRoutesPrefix || ! $needsRoutesPrefix)) {
                 return $url;
             }
 
             // Case 3: Has locale but missing routes_prefix
-            if ($hasLocalePrefix && $needsRoutesPrefix && !$hasRoutesPrefix) {
+            if ($hasLocalePrefix && $needsRoutesPrefix && ! $hasRoutesPrefix) {
                 return tallcms_localized_url($slugAfterPrefixes, $foundLocale);
             }
 
             // Case 4: Has routes_prefix but missing required locale
-            if ($hasRoutesPrefix && $needsLocalePrefix && !$hasLocalePrefix) {
+            if ($hasRoutesPrefix && $needsLocalePrefix && ! $hasLocalePrefix) {
                 return tallcms_localized_url($slugAfterPrefixes);
             }
 
@@ -980,17 +967,17 @@ if (!function_exists('tallcms_resolve_custom_url')) {
     }
 }
 
-if (!function_exists('tallcms_alternate_urls')) {
+if (! function_exists('tallcms_alternate_urls')) {
     /**
      * Get alternate URLs for all translations of a model.
      * Returns array keyed by internal locale code with BCP-47 formatted URLs.
      *
-     * @param Model $model Model with HasTranslatableContent
+     * @param  \Illuminate\Database\Eloquent\Model  $model  Model with HasTranslatableContent
      * @return array<string, string> [locale => url]
      */
     function tallcms_alternate_urls($model): array
     {
-        $registry = app(LocaleRegistry::class);
+        $registry = app(\TallCms\Cms\Services\LocaleRegistry::class);
         $urls = [];
 
         foreach ($registry->getLocaleCodes() as $locale) {
@@ -1005,7 +992,7 @@ if (!function_exists('tallcms_alternate_urls')) {
     }
 }
 
-if (!function_exists('tallcms_current_locale')) {
+if (! function_exists('tallcms_current_locale')) {
     /**
      * Get current locale with i18n awareness.
      * Returns the app locale, which is set by SetLocaleMiddleware.
@@ -1018,7 +1005,7 @@ if (!function_exists('tallcms_current_locale')) {
     }
 }
 
-if (!function_exists('tallcms_i18n_enabled')) {
+if (! function_exists('tallcms_i18n_enabled')) {
     /**
      * Check if i18n is enabled.
      *
@@ -1030,7 +1017,7 @@ if (!function_exists('tallcms_i18n_enabled')) {
     }
 }
 
-if (!function_exists('tallcms_search_url')) {
+if (! function_exists('tallcms_search_url')) {
     /**
      * Get the search page URL respecting i18n and plugin mode prefixes.
      *
@@ -1056,14 +1043,14 @@ if (!function_exists('tallcms_search_url')) {
 
         // Add locale prefix if i18n is enabled with prefix strategy
         if (tallcms_i18n_enabled() && $urlStrategy === 'prefix') {
-            $registry = app(LocaleRegistry::class);
+            $registry = app(\TallCms\Cms\Services\LocaleRegistry::class);
             $currentLocale = tallcms_current_locale();
             $defaultLocale = $registry->getDefaultLocale();
             $hideDefault = config('tallcms.i18n.hide_default_locale', true);
 
             // Add locale prefix unless it's hidden default
-            if (!($hideDefault && $currentLocale === $defaultLocale)) {
-                $segments[] = LocaleRegistry::toBcp47($currentLocale);
+            if (! ($hideDefault && $currentLocale === $defaultLocale)) {
+                $segments[] = \TallCms\Cms\Services\LocaleRegistry::toBcp47($currentLocale);
             }
         }
 
@@ -1073,14 +1060,14 @@ if (!function_exists('tallcms_search_url')) {
 
         // For 'none' strategy, append ?lang= query parameter
         if (tallcms_i18n_enabled() && $urlStrategy === 'none') {
-            $registry = app(LocaleRegistry::class);
+            $registry = app(\TallCms\Cms\Services\LocaleRegistry::class);
             $currentLocale = tallcms_current_locale();
             $defaultLocale = $registry->getDefaultLocale();
             $hideDefault = config('tallcms.i18n.hide_default_locale', true);
 
             // Append ?lang= unless it's hidden default
-            if (!($hideDefault && $currentLocale === $defaultLocale)) {
-                $bcp47 = LocaleRegistry::toBcp47($currentLocale);
+            if (! ($hideDefault && $currentLocale === $defaultLocale)) {
+                $bcp47 = \TallCms\Cms\Services\LocaleRegistry::toBcp47($currentLocale);
 
                 return $baseUrl.'?lang='.$bcp47;
             }
@@ -1090,7 +1077,7 @@ if (!function_exists('tallcms_search_url')) {
     }
 }
 
-if (!function_exists('tallcms_current_slug')) {
+if (! function_exists('tallcms_current_slug')) {
     /**
      * Extract the clean content slug from the current request path.
      *
@@ -1124,9 +1111,9 @@ if (!function_exists('tallcms_current_slug')) {
 
         // Strip locale prefix if i18n is enabled with prefix strategy
         if (tallcms_i18n_config('enabled', false) && config('tallcms.i18n.url_strategy', 'prefix') === 'prefix') {
-            $registry = app(LocaleRegistry::class);
+            $registry = app(\TallCms\Cms\Services\LocaleRegistry::class);
             foreach ($registry->getLocaleCodes() as $localeCode) {
-                $bcp47 = LocaleRegistry::toBcp47($localeCode);
+                $bcp47 = \TallCms\Cms\Services\LocaleRegistry::toBcp47($localeCode);
                 if (str_starts_with($path, $bcp47.'/')) {
                     $path = substr($path, strlen($bcp47) + 1);
                     break;
@@ -1140,18 +1127,18 @@ if (!function_exists('tallcms_current_slug')) {
     }
 }
 
-if (!function_exists('tallcms_locale_label')) {
+if (! function_exists('tallcms_locale_label')) {
     /**
      * Get the display label (native name) for a locale code.
      *
-     * @param string $localeCode The locale code (internal or BCP-47 format)
-     * @param bool $native Whether to return native name (true) or English label (false)
+     * @param  string  $localeCode  The locale code (internal or BCP-47 format)
+     * @param  bool  $native  Whether to return native name (true) or English label (false)
      * @return string The locale label, or the code itself if not found
      */
     function tallcms_locale_label(string $localeCode, bool $native = true): string
     {
-        $registry = app(LocaleRegistry::class);
-        $normalized = LocaleRegistry::normalizeLocaleCode($localeCode);
+        $registry = app(\TallCms\Cms\Services\LocaleRegistry::class);
+        $normalized = \TallCms\Cms\Services\LocaleRegistry::normalizeLocaleCode($localeCode);
         $locales = $registry->getLocales();
 
         if (isset($locales[$normalized])) {
@@ -1164,7 +1151,7 @@ if (!function_exists('tallcms_locale_label')) {
     }
 }
 
-if (!function_exists('tallcms_review_workflow_enabled')) {
+if (! function_exists('tallcms_review_workflow_enabled')) {
     /**
      * Check if the review workflow is enabled for the current site.
      *
@@ -1184,14 +1171,14 @@ if (!function_exists('tallcms_review_workflow_enabled')) {
         $multisiteActive = false;
         try {
             if (class_exists('Tallcms\Multisite\Scopes\SiteScope')) {
-                $multisiteActive = CmsPage::hasGlobalScope('Tallcms\Multisite\Scopes\SiteScope');
+                $multisiteActive = \TallCms\Cms\Models\CmsPage::hasGlobalScope('Tallcms\Multisite\Scopes\SiteScope');
             }
-        } catch (Throwable) {
+        } catch (\Throwable) {
         }
-        $default = !$multisiteActive;
+        $default = ! $multisiteActive;
 
         try {
-            $value = SiteSetting::get('review_workflow_enabled');
+            $value = \TallCms\Cms\Models\SiteSetting::get('review_workflow_enabled');
 
             // If not explicitly set, use the default
             if ($value === null || $value === '') {
@@ -1199,13 +1186,13 @@ if (!function_exists('tallcms_review_workflow_enabled')) {
             }
 
             return filter_var($value, FILTER_VALIDATE_BOOLEAN);
-        } catch (Throwable) {
+        } catch (\Throwable) {
             return $default;
         }
     }
 }
 
-if (!function_exists('tallcms_base_url')) {
+if (! function_exists('tallcms_base_url')) {
     /**
      * Get the canonical base URL for the current site context.
      *
@@ -1218,7 +1205,7 @@ if (!function_exists('tallcms_base_url')) {
         // Explicit site_id: look up the domain directly
         if ($siteId !== null) {
             try {
-                $domain = DB::table('tallcms_sites')
+                $domain = \Illuminate\Support\Facades\DB::table('tallcms_sites')
                     ->where('id', $siteId)
                     ->value('domain');
 
@@ -1228,7 +1215,7 @@ if (!function_exists('tallcms_base_url')) {
 
                     return "{$scheme}://{$domain}";
                 }
-            } catch (Throwable) {
+            } catch (\Throwable) {
             }
         }
 
@@ -1242,7 +1229,7 @@ if (!function_exists('tallcms_base_url')) {
     }
 }
 
-if (!function_exists('tallcms_multisite_active')) {
+if (! function_exists('tallcms_multisite_active')) {
     /**
      * Check if the multisite plugin is actively running.
      *
@@ -1254,9 +1241,9 @@ if (!function_exists('tallcms_multisite_active')) {
     {
         try {
             if (class_exists('Tallcms\Multisite\Scopes\SiteScope')) {
-                return CmsPage::hasGlobalScope('Tallcms\Multisite\Scopes\SiteScope');
+                return \TallCms\Cms\Models\CmsPage::hasGlobalScope('Tallcms\Multisite\Scopes\SiteScope');
             }
-        } catch (Throwable) {
+        } catch (\Throwable) {
         }
 
         return false;

--- a/packages/tallcms/cms/tests/Feature/MenuCacheInvalidationTest.php
+++ b/packages/tallcms/cms/tests/Feature/MenuCacheInvalidationTest.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace TallCms\Cms\Tests\Feature;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use TallCms\Cms\Models\CmsPage;
+use TallCms\Cms\Models\SiteSetting;
+use TallCms\Cms\Models\TallcmsMenu;
+use TallCms\Cms\Models\TallcmsMenuItem;
+use TallCms\Cms\Tests\TestCase;
+
+class MenuCacheInvalidationTest extends TestCase
+{
+    protected function defineDatabaseMigrations(): void
+    {
+        parent::defineDatabaseMigrations();
+
+        Schema::create('tallcms_pages', function (Blueprint $table) {
+            $table->id();
+            $table->json('title');
+            $table->json('slug');
+            $table->json('content')->nullable();
+            $table->text('search_content')->nullable();
+            $table->json('meta_title')->nullable();
+            $table->json('meta_description')->nullable();
+            $table->string('featured_image')->nullable();
+            $table->string('status')->default('draft');
+            $table->timestamp('published_at')->nullable();
+            $table->boolean('is_homepage')->default(false);
+            $table->unsignedBigInteger('parent_id')->nullable();
+            $table->integer('sort_order')->default(0);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('tallcms_revisions', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('revisionable');
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->text('title');
+            $table->text('excerpt')->nullable();
+            $table->json('content')->nullable();
+            $table->text('meta_title')->nullable();
+            $table->text('meta_description')->nullable();
+            $table->string('featured_image')->nullable();
+            $table->json('additional_data')->nullable();
+            $table->unsignedInteger('revision_number');
+            $table->text('notes')->nullable();
+            $table->string('content_hash')->nullable();
+            $table->boolean('is_manual')->default(false);
+            $table->timestamps();
+        });
+
+        Schema::create('tallcms_menus', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('location')->unique();
+            $table->text('description')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+
+        Schema::create('tallcms_menu_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('menu_id')->constrained('tallcms_menus')->cascadeOnDelete();
+            $table->json('label');
+            $table->enum('type', ['page', 'external', 'custom', 'separator', 'header']);
+            $table->foreignId('page_id')->nullable()->constrained('tallcms_pages')->cascadeOnDelete();
+            $table->text('url')->nullable();
+            $table->json('meta')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->nestedSet();
+            $table->timestamps();
+        });
+
+        Schema::create('tallcms_site_settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+            $table->string('type')->default('text');
+            $table->string('group')->default('general');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::setDefaultDriver('array');
+        Cache::flush();
+        Config::set('tallcms.pages.hierarchical_urls', true);
+        app()->setLocale('en');
+    }
+
+    public function test_page_slug_changes_flush_cached_resolved_menu_urls_for_descendants(): void
+    {
+        $parent = $this->createPage('Services', 'services');
+        $child = $this->createPage('Team', 'team', ['parent_id' => $parent->id]);
+        $this->createMenuForPage($child);
+
+        $this->assertSame('/services/team', $this->headerMenuUrl());
+
+        $parent->update(['slug' => ['en' => 'company']]);
+        $this->forgetResolvedMenusForRequest();
+
+        $this->assertSame('/company/team', $this->headerMenuUrl());
+    }
+
+    public function test_page_parent_changes_flush_cached_resolved_menu_urls(): void
+    {
+        $firstParent = $this->createPage('Services', 'services');
+        $secondParent = $this->createPage('Company', 'company');
+        $child = $this->createPage('Team', 'team', ['parent_id' => $firstParent->id]);
+        $this->createMenuForPage($child);
+
+        $this->assertSame('/services/team', $this->headerMenuUrl());
+
+        $child->update(['parent_id' => $secondParent->id]);
+        $this->forgetResolvedMenusForRequest();
+
+        $this->assertSame('/company/team', $this->headerMenuUrl());
+    }
+
+    public function test_menu_helper_reuses_cached_tree_without_requerying_database(): void
+    {
+        $this->createMenuForExternalUrl('/docs');
+
+        $queries = [];
+        DB::listen(function ($query) use (&$queries): void {
+            $queries[] = $query->sql;
+        });
+
+        $firstMenu = menu('header');
+        $queryCountAfterFirstCall = count($queries);
+
+        $this->forgetResolvedMenusForRequest();
+
+        $secondMenu = menu('header');
+
+        $this->assertNotNull($firstMenu);
+        $this->assertSame($firstMenu, $secondMenu);
+        $this->assertGreaterThan(0, $queryCountAfterFirstCall);
+        $this->assertCount($queryCountAfterFirstCall, $queries);
+        $this->assertSame(1, $this->countQueriesForTable($queries, 'tallcms_menus'));
+    }
+
+    public function test_page_homepage_state_changes_flush_cached_resolved_menu_urls(): void
+    {
+        $page = $this->createPage('About', 'about');
+        $this->createMenuForPage($page);
+
+        $this->assertSame('/about', $this->headerMenuUrl());
+
+        $page->update(['is_homepage' => true]);
+        $this->forgetResolvedMenusForRequest();
+
+        $this->assertSame('/', $this->headerMenuUrl());
+    }
+
+    public function test_site_type_changes_flush_cached_resolved_menu_urls(): void
+    {
+        SiteSetting::setGlobal('site_type', 'multi-page');
+        $page = $this->createPage('About', 'about');
+        $this->createMenuForPage($page);
+
+        $this->assertSame('/about', $this->headerMenuUrl());
+
+        SiteSetting::setGlobal('site_type', 'single-page');
+        $this->forgetResolvedMenusForRequest();
+
+        $this->assertSame('#about-'.$page->id, $this->headerMenuUrl());
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    private function createPage(string $title, string $slug, array $attributes = []): CmsPage
+    {
+        return CmsPage::create(array_merge([
+            'title' => ['en' => $title],
+            'slug' => ['en' => $slug],
+            'status' => 'published',
+        ], $attributes));
+    }
+
+    private function createMenuForExternalUrl(string $url): void
+    {
+        $menu = TallcmsMenu::create([
+            'name' => 'Header',
+            'location' => 'header',
+            'is_active' => true,
+        ]);
+
+        TallcmsMenuItem::create([
+            'menu_id' => $menu->id,
+            'label' => ['en' => 'Docs'],
+            'type' => 'external',
+            'url' => $url,
+            'is_active' => true,
+        ]);
+    }
+
+    private function createMenuForPage(CmsPage $page): void
+    {
+        $menu = TallcmsMenu::create([
+            'name' => 'Header',
+            'location' => 'header',
+            'is_active' => true,
+        ]);
+
+        TallcmsMenuItem::create([
+            'menu_id' => $menu->id,
+            'label' => ['en' => $page->title],
+            'type' => 'page',
+            'page_id' => $page->id,
+            'is_active' => true,
+        ]);
+    }
+
+    private function headerMenuUrl(): ?string
+    {
+        return menu('header')[0]['url'] ?? null;
+    }
+
+    private function forgetResolvedMenusForRequest(): void
+    {
+        request()->attributes->remove('tallcms.resolved_menus');
+    }
+
+    /**
+     * @param  array<int, string>  $queries
+     */
+    private function countQueriesForTable(array $queries, string $table): int
+    {
+        return collect($queries)
+            ->filter(fn (string $query): bool => str_contains($query, $table))
+            ->count();
+    }
+}

--- a/packages/tallcms/cms/tests/Unit/MenuCacheTest.php
+++ b/packages/tallcms/cms/tests/Unit/MenuCacheTest.php
@@ -3,12 +3,29 @@
 namespace TallCms\Cms\Tests\Unit;
 
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use TallCms\Cms\Support\MenuCache;
 use TallCms\Cms\Tests\TestCase;
 
 class MenuCacheTest extends TestCase
 {
+    private string $fileCachePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->fileCachePath = storage_path('framework/cache/menu-cache-test');
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->fileCachePath);
+
+        parent::tearDown();
+    }
+
     public function test_it_uses_tagged_cache_when_the_store_supports_tags(): void
     {
         Cache::setDefaultDriver('array');
@@ -49,7 +66,7 @@ class MenuCacheTest extends TestCase
         config()->set('cache.default', 'file');
         config()->set('cache.stores.file', [
             'driver' => 'file',
-            'path' => storage_path('framework/cache/data'),
+            'path' => $this->fileCachePath,
         ]);
         Cache::setDefaultDriver('file');
         Cache::purge('file');

--- a/packages/tallcms/cms/tests/Unit/MenuCacheTest.php
+++ b/packages/tallcms/cms/tests/Unit/MenuCacheTest.php
@@ -9,6 +9,41 @@ use TallCms\Cms\Tests\TestCase;
 
 class MenuCacheTest extends TestCase
 {
+    public function test_it_uses_tagged_cache_when_the_store_supports_tags(): void
+    {
+        Cache::setDefaultDriver('array');
+        Cache::purge('array');
+        Cache::flush();
+
+        $this->assertTrue(Cache::supportsTags());
+
+        $calls = 0;
+        $key = 'tallcms.menu.test.'.Str::random(8);
+
+        $this->assertSame('cached-menu', MenuCache::remember($key, now()->addHour(), function () use (&$calls): string {
+            $calls++;
+
+            return 'cached-menu';
+        }));
+
+        $this->assertSame('cached-menu', MenuCache::remember($key, now()->addHour(), function () use (&$calls): string {
+            $calls++;
+
+            return 'cached-menu';
+        }));
+
+        $this->assertSame(1, $calls);
+        $this->assertTrue(MenuCache::flush());
+
+        $this->assertSame('cached-menu', MenuCache::remember($key, now()->addHour(), function () use (&$calls): string {
+            $calls++;
+
+            return 'cached-menu';
+        }));
+
+        $this->assertSame(2, $calls);
+    }
+
     public function test_it_uses_versioned_fallback_for_cache_stores_without_tags(): void
     {
         config()->set('cache.default', 'file');
@@ -16,8 +51,12 @@ class MenuCacheTest extends TestCase
             'driver' => 'file',
             'path' => storage_path('framework/cache/data'),
         ]);
+        Cache::setDefaultDriver('file');
+        Cache::purge('file');
 
         Cache::flush();
+
+        $this->assertFalse(Cache::supportsTags());
 
         $calls = 0;
         $key = 'tallcms.menu.test.'.Str::random(8);

--- a/packages/tallcms/cms/tests/Unit/MenuCacheTest.php
+++ b/packages/tallcms/cms/tests/Unit/MenuCacheTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace TallCms\Cms\Tests\Unit;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use TallCms\Cms\Support\MenuCache;
+use TallCms\Cms\Tests\TestCase;
+
+class MenuCacheTest extends TestCase
+{
+    public function test_it_uses_versioned_fallback_for_cache_stores_without_tags(): void
+    {
+        config()->set('cache.default', 'file');
+        config()->set('cache.stores.file', [
+            'driver' => 'file',
+            'path' => storage_path('framework/cache/data'),
+        ]);
+
+        Cache::flush();
+
+        $calls = 0;
+        $key = 'tallcms.menu.test.'.Str::random(8);
+
+        $this->assertSame('cached-menu', MenuCache::remember($key, now()->addHour(), function () use (&$calls): string {
+            $calls++;
+
+            return 'cached-menu';
+        }));
+
+        $this->assertSame('cached-menu', MenuCache::remember($key, now()->addHour(), function () use (&$calls): string {
+            $calls++;
+
+            return 'cached-menu';
+        }));
+
+        $this->assertSame(1, $calls);
+        $this->assertTrue(MenuCache::flush());
+
+        $this->assertSame('cached-menu', MenuCache::remember($key, now()->addHour(), function () use (&$calls): string {
+            $calls++;
+
+            return 'cached-menu';
+        }));
+
+        $this->assertSame(2, $calls);
+    }
+}

--- a/packages/tallcms/cms/tests/Unit/SiteSettingSiteNameMemoTest.php
+++ b/packages/tallcms/cms/tests/Unit/SiteSettingSiteNameMemoTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace TallCms\Cms\Tests\Unit;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use TallCms\Cms\Models\SiteSetting;
+use TallCms\Cms\Tests\TestCase;
+
+class SiteSettingSiteNameMemoTest extends TestCase
+{
+    protected function defineDatabaseMigrations(): void
+    {
+        parent::defineDatabaseMigrations();
+
+        Schema::create('tallcms_sites', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('domain')->unique();
+            $table->string('theme')->nullable();
+            $table->string('locale')->nullable();
+            $table->string('uuid')->unique()->nullable();
+            $table->unsignedBigInteger('user_id')->nullable()->index();
+            $table->boolean('is_default')->default(false);
+            $table->boolean('is_active')->default(true);
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('tallcms_site_settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+            $table->string('type')->default('text');
+            $table->string('group')->default('general');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::setDefaultDriver('array');
+        Cache::flush();
+        SiteSetting::forgetMemoizedDefaultSiteId();
+    }
+
+    protected function tearDown(): void
+    {
+        SiteSetting::forgetMemoizedDefaultSiteId();
+
+        parent::tearDown();
+    }
+
+    public function test_setting_site_name_clears_request_and_static_site_name_memos(): void
+    {
+        $siteId = $this->createDefaultSite('Old Site');
+
+        $this->assertSame('Old Site', SiteSetting::get('site_name'));
+
+        SiteSetting::set('site_name', 'New Site');
+
+        $this->assertSame('New Site', SiteSetting::get('site_name'));
+        $this->assertSame('New Site', $this->siteName($siteId));
+    }
+
+    public function test_missing_global_setting_is_cached_without_requerying(): void
+    {
+        $queries = [];
+        DB::listen(function ($query) use (&$queries): void {
+            if (str_contains($query->sql, 'tallcms_site_settings')) {
+                $queries[] = $query->sql;
+            }
+        });
+
+        $this->assertSame('fallback', SiteSetting::getGlobal('missing_setting', 'fallback'));
+
+        SiteSetting::forgetMemoizedDefaultSiteId();
+
+        $this->assertSame('fallback', SiteSetting::getGlobal('missing_setting', 'fallback'));
+        $this->assertCount(1, $queries);
+    }
+
+    private function createDefaultSite(string $name): int
+    {
+        return (int) DB::table('tallcms_sites')->insertGetId([
+            'name' => $name,
+            'domain' => 'example.test',
+            'uuid' => 'site-uuid',
+            'is_default' => true,
+            'is_active' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function siteName(int $siteId): ?string
+    {
+        return DB::table('tallcms_sites')
+            ->where('id', $siteId)
+            ->value('name');
+    }
+}


### PR DESCRIPTION
## Summary

  Improves rendering performance for CMS pages with many blocks by caching expensive repeated CMS rendering work — menu tree composition and site setting lookups — that previously ran on every request.

  ## Changes

  - Cache the resolved menu tree per location / locale / host so repeated `menu()` calls
  don't rebuild the same structure on every request. Active-item state is overlaid
  per-request so the cached tree still highlights correctly for the current URL.
  - Add a `MenuCache` helper that uses tagged cache when the store supports it, with a
  versioned-key fallback for non-tag stores.
  - Invalidate the menu cache on `TallcmsMenu` / `TallcmsMenuItem` save/delete, on
  `CmsPage` slug / parent / homepage changes, and on writes to URL-affecting site settings
  (`site_type`, `i18n_enabled`, `default_locale`, `hide_default_locale`,
  `i18n_locale_overrides`).
  - Memoize site setting lookups within a request and negative-cache missing values so
  absent settings don't re-query on every read.
  - Clear request-scoped and static site-name memos when `site_name` is written, so
  subsequent reads in the same request (and across requests on long-running workers) return
   the new value.
  ## Why

  Large CMS pages with many blocks were doing repeated rendering, menu composition, and settings lookups during a single page request. This made server response time grow noticeably as page complexity increased.

  ## Timings

  Measured on the development server using the same large CMS page:

  - Before changes: around `1.7s - 2.0s`
  - After changes: around `240ms - 260ms`

  Production also improved after deployment once Redis was used as the persistent cache store instead of the array cache.

  ## Validation

  - Tested locally with a large CMS performance page containing many CMS blocks.
  - Compared page load timing before and after the caching changes.
  - Verified behavior on the development server and production deployment.
  - Confirmed the cache must use a persistent store such as Redis; array cache only persists during a single request.

  ## Notes

  This change was developed with assistance from OpenAI Codex / ChatGPT during analysis, implementation, testing, and performance comparison.