### PR TITLE
Fix hero parallax background-attachment on iOS Safari

### DIFF
--- a/packages/tallcms/cms/resources/views/cms/blocks/hero.blade.php
+++ b/packages/tallcms/cms/resources/views/cms/blocks/hero.blade.php
@@ -50,8 +50,14 @@
         $secondary_button_classes = "btn btn-ghost {$buttonSize}";
     }
 
+    // Parallax: iOS Safari renders background-attachment: fixed incorrectly
+    // (image is sized to viewport, not element — appears zoomed/cropped).
+    // The .parallax-block .parallax-bg rule in tallcms.css disables it on
+    // touch/mobile/reduced-motion; opt the hero into that rule.
+    $parallaxEnabled = $hasBackgroundImage && ($parallax_effect ?? true);
+
     // Section classes - keep -mt-20 for non-preview (tucks under nav)
-    $sectionClasses = "hero {$height} " . ($isPreview ? '' : '-mt-20') . " relative overflow-hidden " . ($css_classes ?? '');
+    $sectionClasses = "hero {$height} " . ($isPreview ? '' : '-mt-20') . " relative overflow-hidden " . ($parallaxEnabled ? 'parallax-block ' : '') . ($css_classes ?? '');
 
     // Animation config
     $animationType = $animation_type ?? '';
@@ -67,10 +73,10 @@
 >
     {{-- Background (custom overlay div for opacity control, NOT .hero-overlay) --}}
     @if($hasBackgroundImage)
-        <div class="absolute inset-0 z-0"
+        <div class="absolute inset-0 z-0 {{ $parallaxEnabled ? 'parallax-bg' : '' }}"
              style="background-image: url('{{ Storage::disk(cms_media_disk())->url($background_image) }}');
                     background-size: cover; background-position: center;
-                    @if($parallax_effect ?? true) background-attachment: fixed; @endif">
+                    @if($parallaxEnabled) background-attachment: fixed; @endif">
             <div class="absolute inset-0" style="background-color: rgba(0, 0, 0, {{ $overlayOpacity }});"></div>
         </div>
     @else

--- a/resources/css/tallcms.css
+++ b/resources/css/tallcms.css
@@ -199,3 +199,22 @@
         @apply my-8 border-base-300;
     }
 }
+
+/* ============================================
+   Parallax - Mobile/Accessibility Fallbacks
+   Disable background-attachment: fixed on iOS
+   Safari (which renders it incorrectly), touch
+   devices, and reduced-motion users.
+   Applied to Hero and Parallax blocks.
+   ============================================ */
+@media (prefers-reduced-motion: reduce) {
+    .parallax-block .parallax-bg {
+        background-attachment: scroll !important;
+    }
+}
+
+@media (max-width: 768px), (hover: none) {
+    .parallax-block .parallax-bg {
+        background-attachment: scroll !important;
+    }
+}

--- a/resources/views/cms/blocks/hero.blade.php
+++ b/resources/views/cms/blocks/hero.blade.php
@@ -50,17 +50,23 @@
         $secondary_button_classes = "btn btn-ghost {$buttonSize}";
     }
 
+    // Parallax: iOS Safari renders background-attachment: fixed incorrectly
+    // (image is sized to viewport, not element — appears zoomed/cropped).
+    // The .parallax-block .parallax-bg rule in tallcms.css disables it on
+    // touch/mobile/reduced-motion; opt the hero into that rule.
+    $parallaxEnabled = $hasBackgroundImage && ($parallax_effect ?? true);
+
     // Section classes - keep -mt-20 for non-preview (tucks under nav)
-    $sectionClasses = "hero {$height} " . ($isPreview ? '' : '-mt-20') . " relative overflow-hidden " . ($css_classes ?? '');
+    $sectionClasses = "hero {$height} " . ($isPreview ? '' : '-mt-20') . " relative overflow-hidden " . ($parallaxEnabled ? 'parallax-block ' : '') . ($css_classes ?? '');
 @endphp
 
 <section @if($anchor_id ?? null) id="{{ $anchor_id }}" @endif class="{{ trim($sectionClasses) }}">
     {{-- Background (custom overlay div for opacity control, NOT .hero-overlay) --}}
     @if($hasBackgroundImage)
-        <div class="absolute inset-0 z-0"
+        <div class="absolute inset-0 z-0 {{ $parallaxEnabled ? 'parallax-bg' : '' }}"
              style="background-image: url('{{ Storage::disk(cms_media_disk())->url($background_image) }}');
                     background-size: cover; background-position: center;
-                    @if($parallax_effect ?? true) background-attachment: fixed; @endif">
+                    @if($parallaxEnabled) background-attachment: fixed; @endif">
             <div class="absolute inset-0" style="background-color: rgba(0, 0, 0, {{ $overlayOpacity }});"></div>
         </div>
     @else


### PR DESCRIPTION
## Summary

- iOS Safari renders `background-attachment: fixed` incorrectly — the background image is sized to the viewport instead of the element, appearing zoomed/cropped. Samsung Internet and desktop browsers render correctly. Reported by a customer on an iPhone vs. Samsung comparison.
- The fix opts the Hero block's background div into the existing `.parallax-block .parallax-bg` media-query fallback (already used by `ParallaxBlock`), which switches `background-attachment` to `scroll` on touch devices, small viewports, and reduced-motion preference.
- The standalone copy of `tallcms.css` was missing the parallax override rules that the package copy has — added them to match.

## Changes

- `packages/tallcms/cms/resources/views/cms/blocks/hero.blade.php` — add `parallax-block` / `parallax-bg` classes when parallax is enabled
- `resources/views/cms/blocks/hero.blade.php` — same change on the standalone override
- `resources/css/tallcms.css` — add the parallax media-query fallback rules

No new CSS rules in the package — reusing the rules already present at `packages/tallcms/cms/resources/css/tallcms.css:189-203`.

## Test plan

- [ ] Open a hero-with-background page on an iPhone (real device or Chrome DevTools iPhone profile) — background image should scroll with page content, not appear fixed/zoomed
- [ ] Open the same page on desktop Chrome/Safari/Firefox — parallax behavior preserved
- [ ] Open the same page on Android Chrome / Samsung Internet — should match desktop (parallax active) on tablet width, scroll on phone width
- [ ] Verify `prefers-reduced-motion: reduce` disables parallax on all viewports
- [ ] Verify operator-level "parallax effect" toggle in the admin still disables the effect when unchecked

🤖 Generated with [Claude Code](https://claude.com/claude-code)