### PR TITLE
Make registration an opt-in plugin, not a core dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,6 @@ Full guide: [Installation](https://github.com/tallcms/tallcms/blob/main/docs/gs-
 - MySQL 8 / MariaDB 10.3 / SQLite
 - Node 20+ (for building assets)
 
-> **Laravel 13:** the core CMS (`tallcms/cms`) supports Laravel 13. The
-> standalone skeleton currently resolves on Laravel 12 until
-> [`tallcms/filament-registration`](https://packagist.org/packages/tallcms/filament-registration)
-> ships a Laravel 13–compatible release, after which `composer update` picks
-> up Laravel 13 automatically. Tracking in
-> [#61](https://github.com/tallcms/tallcms/issues/61).
-
 ## Documentation
 
 Full documentation lives in the [docs/](docs/) directory. Highlights:

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -60,7 +60,13 @@ class AdminPanelProvider extends PanelProvider
                 HTML)
             )
             ->login()
-            ->registration(Register::class)
+            // Registration is provided by the optional tallcms/filament-registration
+            // plugin. Only wire the captcha-aware Register page when that package is
+            // installed; a bare skeleton ships with no admin sign-up.
+            ->when(
+                class_exists(Register::class),
+                fn (Panel $panel) => $panel->registration(Register::class),
+            )
             ->passwordReset()
             ->emailVerification(isRequired: fn () => (bool) config('registration.email_verification.enabled'))
             ->emailChangeVerification(fn () => (bool) config('registration.email_verification.enabled'))
@@ -97,12 +103,13 @@ class AdminPanelProvider extends PanelProvider
             ])
             ->plugins(array_filter([
                 TallCmsPlugin::make(),
-                // Registration bridge ships as a local plugin under /plugins/tallcms/registration/.
-                // Guard so fresh checkouts (CI release builds, plugin-mode users) without the
-                // plugin installed don't crash on a missing class reference. settingsPage()
-                // swaps in the host-defined Shield-gated subclass so the panel page enforces
-                // View:RegistrationSettings instead of being open to anyone with admin access.
-                class_exists(TallcmsRegistrationBridge::class)
+                // Registration bridge ships as a local plugin under /plugins/tallcms/registration/,
+                // and itself depends on the optional tallcms/filament-registration package. Wire it
+                // only when BOTH the bridge plugin and the package are present, so that neither a
+                // fresh skeleton (no plugin) nor a bridge-installed-without-the-package state crashes
+                // the panel. settingsPage() swaps in the host-defined Shield-gated subclass so the
+                // page enforces View:RegistrationSettings instead of being open to any admin.
+                class_exists(TallcmsRegistrationBridge::class) && class_exists(Register::class)
                     ? TallcmsRegistrationBridge::make()->settingsPage(\App\Filament\Pages\RegistrationSettings::class)
                     : null,
             ]))

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
         "league/flysystem-aws-s3-v3": "^3.30",
         "livewire/livewire": "^4.0",
         "symfony/yaml": "^7.4",
-        "tallcms/cms": "^4.0",
-        "tallcms/filament-registration": "^1.2"
+        "tallcms/cms": "^4.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "86258c02103ca470fa4866b3d858d094",
+    "content-hash": "5b12ec528de5ed589d190dd665c7e456",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -9079,76 +9079,6 @@
                 "symlink": true,
                 "relative": true
             }
-        },
-        {
-            "name": "tallcms/filament-registration",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/tallcms/filament-registration.git",
-                "reference": "0049fb84918fcade457b917ca23db19aa9643eab"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/tallcms/filament-registration/zipball/0049fb84918fcade457b917ca23db19aa9643eab",
-                "reference": "0049fb84918fcade457b917ca23db19aa9643eab",
-                "shasum": ""
-            },
-            "require": {
-                "filament/filament": "^5.0",
-                "illuminate/support": "^11.0|^12.0",
-                "php": "^8.2"
-            },
-            "require-dev": {
-                "laravel/pint": "^1.0",
-                "orchestra/testbench": "^9.0|^10.0",
-                "phpunit/phpunit": "^11.0",
-                "spatie/laravel-permission": "^6.0"
-            },
-            "suggest": {
-                "bezhansalleh/filament-shield": "If you use Shield, subclass RegistrationSettings and add the HasPageShield trait to gate the captcha admin page through Shield permissions.",
-                "spatie/laravel-permission": "Required only if you set FilamentRegistrationPlugin::make()->defaultRole(...) to auto-assign a role on registration. Without it, role assignment is silently skipped."
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "Tallcms\\FilamentRegistration\\Providers\\FilamentRegistrationServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Tallcms\\FilamentRegistration\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "TallCMS",
-                    "email": "support@tallcms.com",
-                    "homepage": "https://tallcms.com"
-                }
-            ],
-            "description": "Filament-native user registration with pluggable captcha (Cloudflare Turnstile, Google reCAPTCHA v3) and configurable default-role assignment.",
-            "homepage": "https://github.com/tallcms/filament-registration",
-            "keywords": [
-                "auth",
-                "captcha",
-                "filament",
-                "filament-plugin",
-                "recaptcha",
-                "registration",
-                "turnstile"
-            ],
-            "support": {
-                "issues": "https://github.com/tallcms/filament-registration/issues",
-                "source": "https://github.com/tallcms/filament-registration"
-            },
-            "time": "2026-04-30T08:21:29+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",


### PR DESCRIPTION
## Problem

The standalone skeleton hard-`require`d `tallcms/filament-registration`, baking the captcha-aware admin register page into every install. It's a separate plugin and shouldn't be a core dependency.

For clarity: this was **never** part of the `tallcms/cms` package — only the standalone skeleton's root `composer.json` (added back in `abacc1a3`, unrelated to the recent Laravel 13 work).

## Changes

- **Remove** `tallcms/filament-registration` from `composer.json` / `composer.lock`.
- **Guard** the panel's `->registration(Register::class)` with `class_exists(Register::class)` so a bare skeleton ships with **no admin sign-up**; the captcha register page wires up only when the plugin is installed.
- **Harden** the registration-bridge guard to require **both** the bridge plugin *and* the package. The previous guard checked only `class_exists(TallcmsRegistrationBridge::class)`, so a "bridge installed without the package" state fataled the entire admin panel. Now it degrades gracefully.
- **Docs:** drop the obsolete README note about the skeleton being Laravel 13–blocked on this package (it's no longer a skeleton dependency; line already lists Laravel 12/13).

## Behaviour

| State | Before | After |
|---|---|---|
| Bare skeleton (empty `/plugins/`) | register page shipped | **no sign-up**, login + password-reset only |
| Bridge plugin installed, package missing | **panel crashes** (class not found) | panel boots, bridge skipped |
| Bridge plugin + package installed | full captcha registration | full captcha registration (unchanged) |

`/plugins/` is gitignored, so the bridge plugin never ships with the skeleton — registration is fully opt-in.

## Verification

- Empty `/plugins/`: `php artisan about` boots; `route:list` shows `admin/login` + `admin/password-reset`, **no `admin/register`**.
- Local bridge plugin present + package removed (the reported crash): panel boots, bridge skipped gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)