### PR TITLE
Drop Laravel 11 from CI matrix and supported range

### DIFF
--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2', '8.3', '8.4']
-        laravel: ['11.*', '12.*', '13.*']
+        laravel: ['12.*', '13.*']
         exclude:
           # Laravel 13 requires PHP 8.3+
           - laravel: '13.*'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ php artisan test --filter=SomeTest             # Filter by test name
 
 Tests use SQLite in-memory database, array cache, and sync queue (configured in `phpunit.xml`).
 
-**Package tests** (CI runs these across PHP 8.2-8.4 + Laravel 11-12):
+**Package tests** (CI runs these across PHP 8.2-8.4 + Laravel 12-13):
 ```bash
 cd packages/tallcms/cms && vendor/bin/phpunit
 ```

--- a/packages/tallcms/cms/composer.json
+++ b/packages/tallcms/cms/composer.json
@@ -50,7 +50,7 @@
         "laravel/sanctum": "^4.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+        "orchestra/testbench": "^10.0 || ^11.0",
         "phpunit/phpunit": "^10.5 || ^11.0",
         "spatie/laravel-translatable": "^6.0",
         "knuckleswtf/scribe": "^4.0 || ^5.0"


### PR DESCRIPTION
## Problem

Every Laravel 11 leg of **Package Tests** has been failing on `main` (and on PRs). The cause is not test failures — it's dependency resolution:

```
composer require laravel/framework:11.*
  Problem 1
    - Root composer.json requires laravel/framework 11.*, found
      laravel/framework[v11.0.0, ..., v11.54.0] but these were not loaded,
      because they are affected by security advisories (PKSA-mdq4-51ck-6kdq, ...).
```

Every published Laravel 11.x release (through 11.54.0) is now flagged by security advisories, and Composer's default `policy.advisories.block` refuses to install them. This is not CI-only — a fresh `composer require tallcms/cms` on Laravel 11 hits the same wall.

Laravel 12 and 13 legs are green; the full suite (626 tests) passes locally on 12/13.

## Fix

Laravel 11 is no longer a viable target — Filament v5 and the standalone skeleton already build on Laravel 12/13. So:

- Remove `11.*` from the `package-tests.yml` matrix
- Drop `orchestra/testbench ^9.0` (the Laravel 11 testbench line) from `require-dev`, leaving `^10.0 || ^11.0`
- Update the CLAUDE.md matrix note to "Laravel 12-13"

## Verification

- `composer validate` passes
- `vendor/bin/phpunit` → 626 tests, 1243 assertions, OK (on Laravel 12/13)
- CI on this PR should show a fully green matrix (no Laravel 11 legs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)