### PR TITLE
Add opt-in root-to-locale redirect for prefixed i18n URLs

### DIFF
--- a/docs/ref-i18n.md
+++ b/docs/ref-i18n.md
@@ -85,6 +85,7 @@ All settings in `config/tallcms.php` under `i18n`:
     'default_locale' => env('TALLCMS_DEFAULT_LOCALE', 'en'),
     'url_strategy' => 'prefix',
     'hide_default_locale' => env('TALLCMS_HIDE_DEFAULT_LOCALE', true),
+    'redirect_root_to_locale' => env('TALLCMS_REDIRECT_ROOT_TO_LOCALE', false),
 ],
 ```
 
@@ -181,6 +182,18 @@ URLs include locale prefix:
 When `hide_default_locale = true`:
 - Default locale: `/about`
 - Other locales: `/zh-CN/about`
+
+### Redirect `/` to Default Locale
+
+When `hide_default_locale = false`, no unprefixed `/` CMS route is registered. Optionally enable `redirect_root_to_locale` (Global Defaults → Languages, or per-site on the Languages tab) to **301** redirect `/` to the default locale prefix (e.g. `/en/`).
+
+| Setting | Scope | Default |
+|---------|-------|---------|
+| `redirect_root_to_locale` | Global default + per-site override | `false` |
+
+Redirect target locale: site locale if set, otherwise global `default_locale`. Query strings are preserved.
+
+Requires: `i18n_enabled`, `url_strategy = prefix`, and `hide_default_locale = false`.
 
 ### Query Parameter Strategy
 

--- a/packages/tallcms/cms/config/tallcms.php
+++ b/packages/tallcms/cms/config/tallcms.php
@@ -501,6 +501,9 @@ return [
         // Hide default locale from URL (/ instead of /en/)
         'hide_default_locale' => env('TALLCMS_HIDE_DEFAULT_LOCALE', true),
 
+        // Redirect bare / to the default locale prefix (e.g. /en/) when hide_default_locale=false
+        'redirect_root_to_locale' => env('TALLCMS_REDIRECT_ROOT_TO_LOCALE', false),
+
         // Fallback when translation missing: 'default', 'empty', 'key'
         'fallback_behavior' => 'default',
 

--- a/packages/tallcms/cms/src/Filament/Pages/GlobalDefaults.php
+++ b/packages/tallcms/cms/src/Filament/Pages/GlobalDefaults.php
@@ -17,6 +17,7 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Tabs;
 use TallCms\Cms\Models\SiteSetting;
 use TallCms\Cms\Services\LocaleRegistry;
+use TallCms\Cms\Services\SiteSettingsService;
 
 /**
  * Global defaults for all site-scoped settings.
@@ -128,6 +129,14 @@ class GlobalDefaults extends Page implements HasForms
         $formData['i18n_enabled'] = SiteSetting::getGlobal('i18n_enabled', config('tallcms.i18n.enabled', false));
         $formData['default_locale'] = SiteSetting::getGlobal('default_locale', config('tallcms.i18n.default_locale', 'en'));
         $formData['hide_default_locale'] = SiteSetting::getGlobal('hide_default_locale', config('tallcms.i18n.hide_default_locale', true));
+        $formData['redirect_root_to_locale'] = SiteSetting::getGlobal(
+            'redirect_root_to_locale',
+            config('tallcms.i18n.redirect_root_to_locale', false)
+        );
+
+        if (! $formData['i18n_enabled'] || $formData['hide_default_locale']) {
+            $formData['redirect_root_to_locale'] = false;
+        }
 
         $this->form->fill($formData);
     }
@@ -177,6 +186,17 @@ class GlobalDefaults extends Page implements HasForms
         }
         if (array_key_exists('hide_default_locale', $data)) {
             SiteSetting::setGlobal('hide_default_locale', $data['hide_default_locale'], 'boolean', 'i18n');
+        }
+
+        $i18nEnabled = (bool) ($data['i18n_enabled'] ?? false);
+        $hideDefault = (bool) ($data['hide_default_locale'] ?? true);
+        $redirectApplicable = $i18nEnabled && ! $hideDefault;
+
+        if ($redirectApplicable && array_key_exists('redirect_root_to_locale', $data)) {
+            SiteSetting::setGlobal('redirect_root_to_locale', $data['redirect_root_to_locale'], 'boolean', 'i18n');
+        } else {
+            SiteSetting::setGlobal('redirect_root_to_locale', false, 'boolean', 'i18n');
+            app(SiteSettingsService::class)->resetAllSitesForKey('redirect_root_to_locale');
         }
 
         SiteSetting::clearCache();
@@ -418,7 +438,12 @@ class GlobalDefaults extends Page implements HasForms
                             ->label('Enable Multilingual Support')
                             ->helperText('When enabled, content can be translated into multiple languages.')
                             ->live()
-                            ->columnSpanFull(),
+                            ->columnSpanFull()
+                            ->afterStateUpdated(function ($state, callable $set): void {
+                                if (! $state) {
+                                    $set('redirect_root_to_locale', false);
+                                }
+                            }),
 
                         Select::make('default_locale')
                             ->label('Default Language')
@@ -432,6 +457,20 @@ class GlobalDefaults extends Page implements HasForms
                             ->label('Hide Default Language in URLs')
                             ->helperText('Default language accessed at / instead of /en/.')
                             ->default(true)
+                            ->live()
+                            ->afterStateUpdated(function ($state, callable $set): void {
+                                if ($state) {
+                                    $set('redirect_root_to_locale', false);
+                                }
+                            })
+                            ->visible(fn ($get) => $get('i18n_enabled')),
+
+                        Toggle::make('redirect_root_to_locale')
+                            ->label('Redirect / to the default locale')
+                            ->helperText('When enabled, visitors to / are redirected to the default language prefix (e.g. /en/). Only applies when Hide Default Language in URLs is off.')
+                            ->default(false)
+                            ->disabled(fn ($get) => ! $get('i18n_enabled') || $get('hide_default_locale'))
+                            ->dehydrated(fn ($get) => $get('i18n_enabled') && ! $get('hide_default_locale'))
                             ->visible(fn ($get) => $get('i18n_enabled')),
                     ])
                     ->columns(2),

--- a/packages/tallcms/cms/src/Filament/Resources/SiteResource/Pages/EditSite.php
+++ b/packages/tallcms/cms/src/Filament/Resources/SiteResource/Pages/EditSite.php
@@ -9,6 +9,7 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\Page;
 use TallCms\Cms\Filament\Resources\SiteResource\SiteResource;
+use TallCms\Cms\Filament\Resources\SiteResource\SiteForm;
 use TallCms\Cms\Models\Site;
 use TallCms\Cms\Services\SiteSettingsService;
 
@@ -69,6 +70,8 @@ class EditSite extends Page implements HasForms
         // Maintenance
         'maintenance_mode' => 'boolean',
         'maintenance_message' => 'text',
+        // Languages
+        'redirect_root_to_locale' => 'boolean',
         // Embed code (per-site overrides; global default writable in single-site EditSite)
         'code_head' => 'text',
         'code_body_start' => 'text',
@@ -102,6 +105,10 @@ class EditSite extends Page implements HasForms
             };
 
             $formData[$key] = $service->getForSite($siteId, $key, $default);
+
+            if ($key === 'redirect_root_to_locale') {
+                $formData[$key] = SiteForm::normalizeRedirectRootToLocaleFormValue($formData[$key]);
+            }
         }
 
         $this->form->fill($formData);
@@ -160,6 +167,11 @@ class EditSite extends Page implements HasForms
 
             // Value differs from global — create or update override
             $service->setForSite($site->id, $key, $value, $type);
+        }
+
+        if (! SiteForm::isRedirectRootToLocaleApplicable()
+            && $service->hasOverride($site->id, 'redirect_root_to_locale')) {
+            $service->resetForSite($site->id, 'redirect_root_to_locale');
         }
 
         // Clear caches

--- a/packages/tallcms/cms/src/Filament/Resources/SiteResource/SiteForm.php
+++ b/packages/tallcms/cms/src/Filament/Resources/SiteResource/SiteForm.php
@@ -13,6 +13,7 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Tabs;
 use Filament\Schemas\Schema;
 use TallCms\Cms\Models\Site;
+use TallCms\Cms\Models\SiteSetting;
 use TallCms\Cms\Services\LocaleRegistry;
 
 class SiteForm
@@ -40,6 +41,7 @@ class SiteForm
                     static::embedCodeTab(),
                     static::publishingTab(),
                     static::maintenanceTab(),
+                    static::languagesTab(includeSiteLocaleField: true),
                 ])
                 ->persistTabInQueryString()
                 ->columnSpanFull(),
@@ -84,7 +86,7 @@ class SiteForm
                     ->columns(2),
 
                 Section::make('Technical')
-                    ->description('Domain, theme, and locale configuration')
+                    ->description('Domain and theme configuration')
                     ->schema([
                         TextInput::make('domain')
                             ->label('Domain')
@@ -98,12 +100,6 @@ class SiteForm
                             ->label('Theme')
                             ->options(fn () => static::getThemeOptions())
                             ->helperText('Visual theme for this site'),
-
-                        Select::make('locale')
-                            ->label('Default Locale')
-                            ->options(fn () => static::getLocaleOptions())
-                            ->searchable()
-                            ->helperText('Primary language for this site'),
                     ])
                     ->columns(2),
             ]);
@@ -331,6 +327,77 @@ class SiteForm
                             ->columnSpanFull(),
                     ]),
             ]);
+    }
+
+    public static function languagesTab(bool $includeSiteLocaleField = false): Tabs\Tab
+    {
+        $schema = [];
+
+        if ($includeSiteLocaleField) {
+            $schema[] = Section::make('Site Language')
+                ->description('Primary language for this site')
+                ->schema([
+                    Select::make('locale')
+                        ->label('Locale')
+                        ->options(fn () => static::getLocaleOptions())
+                        ->searchable()
+                        ->helperText('Used for content and as the redirect target when / redirect is enabled.'),
+                ])
+                ->columns(2);
+        }
+
+        $schema[] = Section::make('URL Routing')
+            ->description('Locale URL behaviour for this site')
+            ->schema(static::languagesRedirectSchema());
+
+        return Tabs\Tab::make('Languages')
+            ->icon('heroicon-o-language')
+            ->schema($schema);
+    }
+
+    /**
+     * Shared redirect toggle schema for standalone and multisite site edit forms.
+     *
+     * @return array<int, \Filament\Forms\Components\Component>
+     */
+    public static function languagesRedirectSchema(): array
+    {
+        return [
+            Toggle::make('redirect_root_to_locale')
+                ->label('Redirect / to the default locale')
+                ->helperText('When enabled, visitors to / are redirected to this site\'s language prefix. Requires multilingual URLs with visible default locale (Global Defaults → Languages → Hide Default Language in URLs off).')
+                ->default(false)
+                ->disabled(fn () => ! static::isRedirectRootToLocaleApplicable())
+                ->dehydrated(fn () => static::isRedirectRootToLocaleApplicable())
+                ->columnSpanFull(),
+        ];
+    }
+
+    /**
+     * Whether the root-to-locale redirect can apply (requires global i18n + visible default locale).
+     */
+    public static function isRedirectRootToLocaleApplicable(): bool
+    {
+        if (! (bool) SiteSetting::getGlobal('i18n_enabled', config('tallcms.i18n.enabled', false))) {
+            return false;
+        }
+
+        return ! (bool) SiteSetting::getGlobal(
+            'hide_default_locale',
+            config('tallcms.i18n.hide_default_locale', true)
+        );
+    }
+
+    /**
+     * Normalize redirect toggle for forms when global URL strategy makes it inapplicable.
+     */
+    public static function normalizeRedirectRootToLocaleFormValue(mixed $value): bool
+    {
+        if (! static::isRedirectRootToLocaleApplicable()) {
+            return false;
+        }
+
+        return (bool) $value;
     }
 
     /**

--- a/packages/tallcms/cms/src/Http/Middleware/MaintenanceModeMiddleware.php
+++ b/packages/tallcms/cms/src/Http/Middleware/MaintenanceModeMiddleware.php
@@ -6,10 +6,9 @@ namespace TallCms\Cms\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Schema;
 use Symfony\Component\HttpFoundation\Response;
 use TallCms\Cms\Models\SiteSetting;
+use TallCms\Cms\Support\InstallationStatus;
 
 class MaintenanceModeMiddleware
 {
@@ -19,7 +18,7 @@ class MaintenanceModeMiddleware
     public function handle(Request $request, Closure $next): Response
     {
         // Skip maintenance mode check if installation is not complete
-        if ($this->installationIncomplete()) {
+        if (InstallationStatus::isIncomplete()) {
             return $next($request);
         }
 
@@ -50,55 +49,5 @@ class MaintenanceModeMiddleware
         }
 
         return $next($request);
-    }
-
-    /**
-     * Check if installation is incomplete
-     */
-    private function installationIncomplete(): bool
-    {
-        // In plugin mode, skip installer.lock check if configured
-        // (host app doesn't use TallCMS's installer)
-        $skipInstallerCheck = config('tallcms.plugin_mode.skip_installer_check', true);
-        $isPluginMode = config('tallcms.mode') === 'plugin' ||
-            (config('tallcms.mode') === null && ! File::exists(base_path('.tallcms-standalone')));
-
-        if ($isPluginMode && $skipInstallerCheck) {
-            // In plugin mode, only check if database tables exist
-            try {
-                return ! Schema::hasTable((new SiteSetting)->getTable());
-            } catch (\Exception $e) {
-                // If we can't check the schema, skip maintenance mode
-                return true;
-            }
-        }
-
-        // Standalone mode: full installation checks
-        // Installation is incomplete if:
-        // 1. No installer lock file exists
-        // 2. Database tables don't exist
-        // 3. .env doesn't exist
-
-        if (! File::exists(base_path('installer.lock')) && ! File::exists(storage_path('installer.lock'))) {
-            return true;
-        }
-
-        if (! File::exists(base_path('.env'))) {
-            return true;
-        }
-
-        try {
-            // Check if database is configured
-            if (empty(config('database.connections.'.config('database.default').'.database'))) {
-                return true;
-            }
-
-            // Check if the settings table exists using the model's table name
-            return ! Schema::hasTable((new SiteSetting)->getTable());
-        } catch (\Exception $e) {
-            // If we can't check the schema, assume installation is incomplete
-            // This handles cases where database isn't configured or accessible
-            return true;
-        }
     }
 }

--- a/packages/tallcms/cms/src/Http/Middleware/RedirectRootToLocaleMiddleware.php
+++ b/packages/tallcms/cms/src/Http/Middleware/RedirectRootToLocaleMiddleware.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TallCms\Cms\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use TallCms\Cms\Models\Site;
+use TallCms\Cms\Models\SiteSetting;
+use TallCms\Cms\Services\LocaleRegistry;
+use TallCms\Cms\Support\InstallationStatus;
+
+/**
+ * Redirect bare / to the locale-prefixed homepage when configured.
+ *
+ * Only applies when i18n uses prefixed URLs with the default locale visible
+ * (hide_default_locale=false) and redirect_root_to_locale is enabled.
+ */
+class RedirectRootToLocaleMiddleware
+{
+    public function __construct(protected LocaleRegistry $registry) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $request->isMethod('GET') && ! $request->isMethod('HEAD')) {
+            return $next($request);
+        }
+
+        // Cheap early exit for non-root paths before any install/DB checks.
+        if ($request->getPathInfo() !== '/') {
+            return $next($request);
+        }
+
+        if (InstallationStatus::isIncomplete()) {
+            return $next($request);
+        }
+
+        if (! tallcms_i18n_config('enabled', false)) {
+            return $next($request);
+        }
+
+        if (config('tallcms.i18n.url_strategy', 'prefix') !== 'prefix') {
+            return $next($request);
+        }
+
+        if (tallcms_i18n_config('hide_default_locale', true)) {
+            return $next($request);
+        }
+
+        if (! (bool) SiteSetting::get(
+            'redirect_root_to_locale',
+            config('tallcms.i18n.redirect_root_to_locale', false)
+        )) {
+            return $next($request);
+        }
+
+        $locale = $this->resolveRedirectLocale($request);
+        $target = tallcms_localized_url('/', $locale);
+
+        if ($query = $request->getQueryString()) {
+            $target .= (str_contains($target, '?') ? '&' : '?').$query;
+        }
+
+        return redirect()->to($target, 301);
+    }
+
+    protected function resolveRedirectLocale(Request $request): string
+    {
+        $siteLocale = $this->resolveSiteLocale($request);
+
+        if ($siteLocale && $this->registry->isValidLocale($siteLocale)) {
+            return $siteLocale;
+        }
+
+        return $this->registry->getDefaultLocale();
+    }
+
+    protected function resolveSiteLocale(Request $request): ?string
+    {
+        if (app()->bound('tallcms.multisite.resolver')) {
+            try {
+                $resolver = app('tallcms.multisite.resolver');
+
+                if (! $resolver->isResolved()) {
+                    $resolver->resolve($request);
+                }
+
+                $site = $resolver->get();
+
+                if ($site && ! empty($site->locale)) {
+                    return LocaleRegistry::normalizeLocaleCode((string) $site->locale);
+                }
+            } catch (\Throwable) {
+                // Fall through to standalone lookup
+            }
+        }
+
+        try {
+            $site = Site::getDefault() ?? Site::query()->first();
+
+            if ($site && ! empty($site->locale)) {
+                return LocaleRegistry::normalizeLocaleCode((string) $site->locale);
+            }
+        } catch (\Throwable) {
+            // Table may not exist yet
+        }
+
+        return null;
+    }
+}

--- a/packages/tallcms/cms/src/Services/SiteSettingsService.php
+++ b/packages/tallcms/cms/src/Services/SiteSettingsService.php
@@ -99,6 +99,27 @@ class SiteSettingsService
     }
 
     /**
+     * Remove a site-specific override for all sites.
+     */
+    public function resetAllSitesForKey(string $key): void
+    {
+        $siteIds = DB::table('tallcms_site_setting_overrides')
+            ->where('key', $key)
+            ->pluck('site_id')
+            ->unique();
+
+        DB::table('tallcms_site_setting_overrides')
+            ->where('key', $key)
+            ->delete();
+
+        foreach ($siteIds as $siteId) {
+            Cache::forget("site_setting_{$siteId}_{$key}");
+        }
+
+        SiteSetting::flushMenuCacheIfSettingAffectsMenuUrls($key);
+    }
+
+    /**
      * Get a global setting value (not site-specific).
      */
     public function getGlobal(string $key, mixed $default = null): mixed

--- a/packages/tallcms/cms/src/Support/InstallationStatus.php
+++ b/packages/tallcms/cms/src/Support/InstallationStatus.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TallCms\Cms\Support;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use TallCms\Cms\Models\SiteSetting;
+
+/**
+ * Shared installation-completeness checks used by frontend middleware.
+ */
+class InstallationStatus
+{
+    /**
+     * Whether TallCMS installation is incomplete (installer not finished, or tables missing).
+     */
+    public static function isIncomplete(): bool
+    {
+        // In plugin mode, skip installer.lock check if configured
+        // (host app doesn't use TallCMS's installer)
+        $skipInstallerCheck = config('tallcms.plugin_mode.skip_installer_check', true);
+        $isPluginMode = config('tallcms.mode') === 'plugin' ||
+            (config('tallcms.mode') === null && ! File::exists(base_path('.tallcms-standalone')));
+
+        if ($isPluginMode && $skipInstallerCheck) {
+            // In plugin mode, only check if database tables exist
+            try {
+                return ! Schema::hasTable((new SiteSetting)->getTable());
+            } catch (\Throwable) {
+                // If we can't check the schema, skip feature middleware
+                return true;
+            }
+        }
+
+        // Standalone mode: full installation checks
+        // Installation is incomplete if:
+        // 1. No installer lock file exists
+        // 2. Database tables don't exist
+        // 3. .env doesn't exist
+
+        if (! File::exists(base_path('installer.lock')) && ! File::exists(storage_path('installer.lock'))) {
+            return true;
+        }
+
+        if (! File::exists(base_path('.env'))) {
+            return true;
+        }
+
+        try {
+            // Check if database is configured
+            if (empty(config('database.connections.'.config('database.default').'.database'))) {
+                return true;
+            }
+
+            // Check if the settings table exists using the model's table name
+            return ! Schema::hasTable((new SiteSetting)->getTable());
+        } catch (\Throwable) {
+            // If we can't check the schema, assume installation is incomplete
+            // This handles cases where database isn't configured or accessible
+            return true;
+        }
+    }
+}

--- a/packages/tallcms/cms/src/TallCmsServiceProvider.php
+++ b/packages/tallcms/cms/src/TallCmsServiceProvider.php
@@ -408,6 +408,7 @@ class TallCmsServiceProvider extends PackageServiceProvider
 
         // Register middleware aliases before loading routes
         $this->registerMiddlewareAliases();
+        $this->registerRootLocaleRedirectMiddleware();
 
         // Register Blade component aliases for theme compatibility
         $this->registerBladeComponentAliases();
@@ -620,11 +621,22 @@ class TallCmsServiceProvider extends PackageServiceProvider
         $router->aliasMiddleware('tallcms.theme-preview', Http\Middleware\ThemePreviewMiddleware::class);
         $router->aliasMiddleware('tallcms.preview-auth', Http\Middleware\PreviewAuthMiddleware::class);
         $router->aliasMiddleware('tallcms.set-locale', Http\Middleware\SetLocaleMiddleware::class);
+        $router->aliasMiddleware('tallcms.redirect-root-locale', Http\Middleware\RedirectRootToLocaleMiddleware::class);
 
         // API middleware
         $router->aliasMiddleware('tallcms.api-enabled', Http\Middleware\EnsureApiEnabled::class);
         $router->aliasMiddleware('tallcms.token-expiry', Http\Middleware\CheckTokenExpiry::class);
         $router->aliasMiddleware('tallcms.abilities', Http\Middleware\CheckTokenAbilities::class);
+    }
+
+    /**
+     * Register root-to-locale redirect as global middleware so it runs even
+     * when no unprefixed / route exists (hide_default_locale=false).
+     */
+    protected function registerRootLocaleRedirectMiddleware(): void
+    {
+        $kernel = $this->app->make(\Illuminate\Contracts\Http\Kernel::class);
+        $kernel->pushMiddleware(Http\Middleware\RedirectRootToLocaleMiddleware::class);
     }
 
     /**

--- a/packages/tallcms/cms/tests/Feature/RedirectRootToLocaleMiddlewareTest.php
+++ b/packages/tallcms/cms/tests/Feature/RedirectRootToLocaleMiddlewareTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace TallCms\Cms\Tests\Feature;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Schema;
+use TallCms\Cms\Models\Site;
+use TallCms\Cms\Models\SiteSetting;
+use TallCms\Cms\Tests\TestCase;
+
+class RedirectRootToLocaleMiddlewareTest extends TestCase
+{
+    protected function defineDatabaseMigrations(): void
+    {
+        parent::defineDatabaseMigrations();
+
+        Schema::create('tallcms_sites', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('domain');
+            $table->string('theme')->nullable();
+            $table->string('locale', 10)->nullable();
+            $table->uuid('uuid')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->boolean('is_default')->default(false);
+            $table->boolean('is_active')->default(true);
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('tallcms_site_settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+            $table->string('type')->default('text');
+            $table->string('group')->nullable();
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('tallcms_site_setting_overrides', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('site_id');
+            $table->string('key');
+            $table->text('value')->nullable();
+            $table->string('type')->default('text');
+            $table->timestamps();
+            $table->unique(['site_id', 'key']);
+        });
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('tallcms.i18n.enabled', true);
+        Config::set('tallcms.i18n.url_strategy', 'prefix');
+        Config::set('tallcms.i18n.hide_default_locale', false);
+        Config::set('tallcms.i18n.default_locale', 'en');
+        Config::set('tallcms.i18n.redirect_root_to_locale', false);
+        Config::set('tallcms.i18n.locales', [
+            'en' => ['label' => 'English', 'native' => 'English', 'rtl' => false],
+            'de' => ['label' => 'German', 'native' => 'Deutsch', 'rtl' => false],
+        ]);
+
+        SiteSetting::setGlobal('i18n_enabled', true, 'boolean', 'i18n');
+        SiteSetting::setGlobal('default_locale', 'en', 'text', 'i18n');
+        SiteSetting::setGlobal('hide_default_locale', false, 'boolean', 'i18n');
+        SiteSetting::setGlobal('redirect_root_to_locale', true, 'boolean', 'i18n');
+        SiteSetting::clearCache();
+
+        Site::query()->create([
+            'name' => 'Default',
+            'domain' => 'localhost',
+            'locale' => 'en',
+            'is_default' => true,
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_root_redirects_to_default_locale_prefix_when_enabled(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertRedirect('/en');
+        $response->assertStatus(301);
+    }
+
+    public function test_root_redirect_preserves_query_string(): void
+    {
+        $response = $this->get('/?utm_source=test');
+
+        $response->assertRedirect('/en?utm_source=test');
+        $response->assertStatus(301);
+    }
+
+    public function test_root_does_not_redirect_when_toggle_disabled(): void
+    {
+        SiteSetting::setGlobal('redirect_root_to_locale', false, 'boolean', 'i18n');
+        SiteSetting::clearCache();
+
+        $response = $this->get('/');
+
+        $this->assertNotEquals(301, $response->getStatusCode());
+        $this->assertNotEquals(302, $response->getStatusCode());
+    }
+
+    public function test_root_does_not_redirect_when_hide_default_locale_is_on(): void
+    {
+        SiteSetting::setGlobal('hide_default_locale', true, 'boolean', 'i18n');
+        SiteSetting::clearCache();
+
+        $response = $this->get('/');
+
+        $this->assertNotEquals(301, $response->getStatusCode());
+    }
+
+    public function test_admin_paths_are_not_redirected(): void
+    {
+        $response = $this->get('/admin');
+
+        $this->assertNotEquals(301, $response->getStatusCode());
+    }
+}

--- a/packages/tallcms/cms/tests/Unit/RedirectRootToLocaleSettingsTest.php
+++ b/packages/tallcms/cms/tests/Unit/RedirectRootToLocaleSettingsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TallCms\Cms\Tests\Unit;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use TallCms\Cms\Filament\Resources\SiteResource\SiteForm;
+use TallCms\Cms\Models\Site;
+use TallCms\Cms\Models\SiteSetting;
+use TallCms\Cms\Services\SiteSettingsService;
+use TallCms\Cms\Tests\TestCase;
+
+class RedirectRootToLocaleSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_redirect_is_not_applicable_when_hide_default_locale_is_on(): void
+    {
+        SiteSetting::setGlobal('i18n_enabled', true, 'boolean', 'i18n');
+        SiteSetting::setGlobal('hide_default_locale', true, 'boolean', 'i18n');
+        SiteSetting::clearCache();
+
+        $this->assertFalse(SiteForm::isRedirectRootToLocaleApplicable());
+        $this->assertFalse(SiteForm::normalizeRedirectRootToLocaleFormValue(true));
+    }
+
+    public function test_redirect_is_applicable_when_i18n_on_and_default_locale_visible(): void
+    {
+        SiteSetting::setGlobal('i18n_enabled', true, 'boolean', 'i18n');
+        SiteSetting::setGlobal('hide_default_locale', false, 'boolean', 'i18n');
+        SiteSetting::clearCache();
+
+        $this->assertTrue(SiteForm::isRedirectRootToLocaleApplicable());
+        $this->assertTrue(SiteForm::normalizeRedirectRootToLocaleFormValue(true));
+    }
+
+    public function test_reset_all_sites_for_key_removes_redirect_overrides(): void
+    {
+        $site = Site::query()->create([
+            'name' => 'Second',
+            'domain' => 'second.test',
+            'is_default' => false,
+            'is_active' => true,
+        ]);
+
+        $service = app(SiteSettingsService::class);
+        $service->setForSite($site->id, 'redirect_root_to_locale', true, 'boolean');
+
+        $this->assertTrue($service->hasOverride($site->id, 'redirect_root_to_locale'));
+
+        $service->resetAllSitesForKey('redirect_root_to_locale');
+
+        $this->assertFalse($service->hasOverride($site->id, 'redirect_root_to_locale'));
+    }
+}


### PR DESCRIPTION
## Summary

Adds an **opt-in** setting to **301-redirect** bare `/` to the default locale prefix (e.g. `/en/`) when multilingual URLs use visible locale prefixes (`hide_default_locale=false`).

Fixes the case where `/` has no CMS route and visitors get a 404 unless something outside TallCMS handles it.

## Problem

With `i18n_enabled=true` and `hide_default_locale=false`, TallCMS registers **only** locale-prefixed routes (`/en/`, `/de/`, etc.). There is no unprefixed `/` route and no redirect today — `/` returns 404.

## Solution

- New setting `redirect_root_to_locale` (global default + per-site override), default **OFF**
- New `RedirectRootToLocaleMiddleware` registered as **global middleware** via `pushMiddleware()` so it runs even when `/` has no matching route
- Admin UI on **Global Defaults → Languages** and a new **Languages** tab on site edit (locale moved out of General/Technical)
- Redirect clears automatically when **Hide Default Language in URLs** or **Enable Multilingual Support** is turned off (UI + DB, including per-site overrides)

<img width="2879" height="1556" alt="image" src="https://github.com/user-attachments/assets/83687746-83ee-461c-88f8-9a737cd3f1e8" />

<img width="2879" height="1550" alt="image" src="https://github.com/user-attachments/assets/d69bf1d2-8bfa-4ca8-9ed0-391a4fba0a60" />



## Behaviour

Redirect applies only when **all** of the following are true:

- `i18n_enabled`
- `url_strategy=prefix`
- `hide_default_locale=false`
- `redirect_root_to_locale=true`
- Exact path `/` (GET/HEAD)
- Not admin, Livewire, API, install, preview, etc.

| Detail | Value |
|--------|-------|
| HTTP status | **301** |
| Target locale | `site.locale` if set, else global `default_locale` |
| Query string | Preserved |
| Env bootstrap | `TALLCMS_REDIRECT_ROOT_TO_LOCALE=false` |

## Changes

- `RedirectRootToLocaleMiddleware` + global registration in `TallCmsServiceProvider`
- `config/tallcms.php` — `redirect_root_to_locale` env key
- `GlobalDefaults` — Languages tab toggle + setting coupling
- `SiteForm` — `languagesTab()`, shared `languagesRedirectSchema()`, applicability helpers
- `EditSite` — load/save `redirect_root_to_locale`
- `SiteSettingsService::resetAllSitesForKey()` — clear stale per-site overrides
- `docs/ref-i18n.md` — documented new setting
- Tests: `RedirectRootToLocaleMiddlewareTest` (5), `RedirectRootToLocaleSettingsTest` (3)

## Backwards compatibility

- Default **OFF** — existing installs unchanged until explicitly enabled
- No route registration changes — redirect is runtime middleware only (route cache unaffected)
- `hide_default_locale=true` (TallCMS default) — redirect toggle disabled; `/` continues to serve the default locale

## Test plan

- [x] `./vendor/bin/phpunit --filter=RedirectRootToLocale` (8 tests)
- [ ] Global Defaults → Languages: i18n on, hide-default **off**, redirect **on** → save
- [ ] Visit `/` → **301** to `/:locale/` with query string preserved
- [ ] `/admin`, `/livewire/*` → no redirect
- [ ] Redirect **off** → `/` does not redirect (404 or non-CMS handler)
- [ ] Hide-default **on** → redirect toggle disabled and forced **off** on save
- [ ] Edit Site → **Languages** tab: locale field + per-site redirect override

## Follow-up (multisite plugin)

Site edit UI for the **Languages** tab and per-site `redirect_root_to_locale` override lives in the **`tallcms/multisite`** plugin (locale moved from the Site tab; wiring via core `SiteForm` helpers). That change is ready locally but **not included in this PR**.

I 'd like to open a companion PR in `tallcms/multisite` if you'd allow me to have fork access to that repository. **Could you grant fork access (or advise on the preferred contribution path for the multisite plugin)?**