### PR TITLE
Fix installation being marked as incomplete on docker deploys

### DIFF
--- a/packages/tallcms/cms/src/Support/InstallationStatus.php
+++ b/packages/tallcms/cms/src/Support/InstallationStatus.php
@@ -34,17 +34,14 @@ class InstallationStatus
             }
         }
 
-        // Standalone mode: full installation checks
-        // Installation is incomplete if:
+        // Standalone mode: installation is incomplete if:
         // 1. No installer lock file exists
-        // 2. Database tables don't exist
-        // 3. .env doesn't exist
+        // 2. Database is not configured / settings table missing
+        //
+        // Do not require base_path('.env'): Docker/K8s inject env via the
+        // process environment. A missing file does not mean install is incomplete.
 
         if (! File::exists(base_path('installer.lock')) && ! File::exists(storage_path('installer.lock'))) {
-            return true;
-        }
-
-        if (! File::exists(base_path('.env'))) {
             return true;
         }
 

--- a/packages/tallcms/cms/tests/Unit/InstallationStatusTest.php
+++ b/packages/tallcms/cms/tests/Unit/InstallationStatusTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TallCms\Cms\Tests\Unit;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use TallCms\Cms\Models\SiteSetting;
+use TallCms\Cms\Support\InstallationStatus;
+use TallCms\Cms\Tests\TestCase;
+
+class InstallationStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @var list<string> */
+    private array $createdPaths = [];
+
+    /** @var array<string, string> path => temporary stash path */
+    private array $stashedPaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdPaths as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+
+        foreach ($this->stashedPaths as $original => $stash) {
+            if (is_file($stash)) {
+                @rename($stash, $original);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_standalone_complete_without_env_file(): void
+    {
+        $this->asStandalone();
+        $this->ensureInstallerLock();
+        $this->ensureAbsent(base_path('.env'));
+
+        $this->assertTrue(File::exists(base_path('installer.lock')));
+        $this->assertFalse(File::exists(base_path('.env')));
+        $this->assertTrue(\Illuminate\Support\Facades\Schema::hasTable((new SiteSetting)->getTable()));
+
+        $this->assertFalse(InstallationStatus::isIncomplete());
+    }
+
+    public function test_standalone_incomplete_without_installer_lock(): void
+    {
+        $this->asStandalone();
+        $this->ensureAbsent(base_path('installer.lock'));
+        $this->ensureAbsent(storage_path('installer.lock'));
+
+        $this->assertTrue(InstallationStatus::isIncomplete());
+    }
+
+    public function test_plugin_mode_only_requires_settings_table(): void
+    {
+        config([
+            'tallcms.mode' => 'plugin',
+            'tallcms.plugin_mode.skip_installer_check' => true,
+        ]);
+
+        $this->ensureAbsent(base_path('installer.lock'));
+        $this->ensureAbsent(storage_path('installer.lock'));
+        $this->ensureAbsent(base_path('.env'));
+
+        $this->assertFalse(InstallationStatus::isIncomplete());
+    }
+
+    public function test_standalone_complete_with_env_file(): void
+    {
+        $this->asStandalone();
+        $this->ensureInstallerLock();
+        $this->ensureFile(base_path('.env'));
+
+        $this->assertFalse(InstallationStatus::isIncomplete());
+    }
+
+    private function asStandalone(): void
+    {
+        config(['tallcms.mode' => 'standalone']);
+    }
+
+    private function ensureInstallerLock(): void
+    {
+        $this->ensureFile(base_path('installer.lock'));
+    }
+
+    private function ensureFile(string $path): void
+    {
+        if (File::exists($path)) {
+            return;
+        }
+
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, '');
+        $this->createdPaths[] = $path;
+    }
+
+    private function ensureAbsent(string $path): void
+    {
+        if (! File::exists($path)) {
+            return;
+        }
+
+        $stash = $path.'.installation-status-test-stash';
+        if (File::exists($stash)) {
+            @unlink($stash);
+        }
+
+        rename($path, $stash);
+        $this->stashedPaths[$path] = $stash;
+    }
+}


### PR DESCRIPTION
Standalone installs currently treat a missing `base_path('.env')` as “installation incomplete,” which causes frontend middleware (e.g. maintenance mode, and any other callers of the same check) to no-op. That assumption fits classic file-based deploys where the installer writes `.env`, but not container deploys (Docker, Coolify, Kubernetes) that inject configuration via process environment variables and never ship a `.env` file. In those setups the app is fully installed (`installer.lock` + DB) yet TallCMS keeps behaving as if setup never finished.

## Summary
- Stop requiring a `.env` **file** for standalone install completeness in `MaintenanceModeMiddleware`.
- Keep `installer.lock` and DB/schema checks as the real signals.
- Plugin-mode behavior is unchanged (schema-only when `skip_installer_check` is on).

## Test plan
- [ ] Standalone with `installer.lock` + settings table, **no** `.env` → not treated as incomplete; maintenance middleware can run
- [ ] Standalone without `installer.lock` → still incomplete
- [ ] Plugin mode → unchanged
- [ ] Classic standalone with a real `.env` → unchanged