### PR TITLE
Fixed default themes page footer not sticking to the bottom

### DIFF
--- a/packages/tallcms/cms/resources/themes/autumn/resources/views/layouts/app.blade.php
+++ b/packages/tallcms/cms/resources/themes/autumn/resources/views/layouts/app.blade.php
@@ -43,7 +43,7 @@
     <style>[x-cloak] { display: none !important; }</style>
     <x-tallcms::code-injection zone="head" />
 </head>
-<body class="min-h-screen bg-base-100 text-base-content">
+<body class="min-h-screen flex flex-col bg-base-100 text-base-content">
     <x-tallcms::code-injection zone="body_start" />
     <!-- Header -->
     @if(function_exists('mega_menu_header_active') && mega_menu_header_active('header'))
@@ -101,7 +101,7 @@
     @endif
 
     <!-- Main Content -->
-    <main>
+    <main class="flex-1">
         {{ $slot ?? '' }}
         @yield('content')
     </main>

--- a/packages/tallcms/cms/resources/themes/blog/resources/views/layouts/app.blade.php
+++ b/packages/tallcms/cms/resources/themes/blog/resources/views/layouts/app.blade.php
@@ -43,7 +43,7 @@
     <style>[x-cloak] { display: none !important; }</style>
     <x-tallcms::code-injection zone="head" />
 </head>
-<body class="min-h-screen bg-base-100 text-base-content">
+<body class="min-h-screen flex flex-col bg-base-100 text-base-content">
     <x-tallcms::code-injection zone="body_start" />
     <!-- Header -->
     @if(function_exists('mega_menu_header_active') && mega_menu_header_active('header'))
@@ -101,7 +101,7 @@
     @endif
 
     <!-- Main Content -->
-    <main>
+    <main class="flex-1">
         {{ $slot ?? '' }}
         @yield('content')
     </main>

--- a/packages/tallcms/cms/resources/themes/corporate/resources/views/layouts/app.blade.php
+++ b/packages/tallcms/cms/resources/themes/corporate/resources/views/layouts/app.blade.php
@@ -43,7 +43,7 @@
     <style>[x-cloak] { display: none !important; }</style>
     <x-tallcms::code-injection zone="head" />
 </head>
-<body class="min-h-screen bg-base-100 text-base-content">
+<body class="min-h-screen flex flex-col bg-base-100 text-base-content">
     <x-tallcms::code-injection zone="body_start" />
     <!-- Header -->
     @if(function_exists('mega_menu_header_active') && mega_menu_header_active('header'))
@@ -101,7 +101,7 @@
     @endif
 
     <!-- Main Content -->
-    <main>
+    <main class="flex-1">
         {{ $slot ?? '' }}
         @yield('content')
     </main>

--- a/packages/tallcms/cms/resources/themes/creative/resources/views/layouts/app.blade.php
+++ b/packages/tallcms/cms/resources/themes/creative/resources/views/layouts/app.blade.php
@@ -43,7 +43,7 @@
     <style>[x-cloak] { display: none !important; }</style>
     <x-tallcms::code-injection zone="head" />
 </head>
-<body class="min-h-screen bg-base-100 text-base-content">
+<body class="min-h-screen flex flex-col bg-base-100 text-base-content">
     <x-tallcms::code-injection zone="body_start" />
     <!-- Header -->
     @if(function_exists('mega_menu_header_active') && mega_menu_header_active('header'))
@@ -101,7 +101,7 @@
     @endif
 
     <!-- Main Content -->
-    <main>
+    <main class="flex-1">
         {{ $slot ?? '' }}
         @yield('content')
     </main>

--- a/packages/tallcms/cms/resources/themes/elevate/resources/views/layouts/app.blade.php
+++ b/packages/tallcms/cms/resources/themes/elevate/resources/views/layouts/app.blade.php
@@ -57,7 +57,7 @@
     <style>[x-cloak] { display: none !important; }</style>
     <x-tallcms::code-injection zone="head" />
 </head>
-<body class="min-h-screen bg-base-100 text-base-content">
+<body class="min-h-screen flex flex-col bg-base-100 text-base-content">
     <x-tallcms::code-injection zone="body_start" />
 
     {{-- Site-wide variables. Defined at layout scope so both the header
@@ -141,7 +141,7 @@
     @endif
 
     <!-- Main Content -->
-    <main>
+    <main class="flex-1">
         {{ $slot ?? '' }}
         @yield('content')
     </main>

--- a/packages/tallcms/cms/resources/themes/luxury/resources/views/layouts/app.blade.php
+++ b/packages/tallcms/cms/resources/themes/luxury/resources/views/layouts/app.blade.php
@@ -44,7 +44,7 @@
     <style>[x-cloak] { display: none !important; }</style>
     <x-tallcms::code-injection zone="head" />
 </head>
-<body class="min-h-screen bg-base-100 text-base-content">
+<body class="min-h-screen flex flex-col bg-base-100 text-base-content">
     <x-tallcms::code-injection zone="body_start" />
     <!-- Header -->
     @if(function_exists('mega_menu_header_active') && mega_menu_header_active('header'))
@@ -101,7 +101,7 @@
     @endif
 
     <!-- Main Content -->
-    <main>
+    <main class="flex-1">
         {{ $slot ?? '' }}
         @yield('content')
     </main>

--- a/packages/tallcms/cms/resources/themes/minimal/resources/views/layouts/app.blade.php
+++ b/packages/tallcms/cms/resources/themes/minimal/resources/views/layouts/app.blade.php
@@ -43,7 +43,7 @@
     <style>[x-cloak] { display: none !important; }</style>
     <x-tallcms::code-injection zone="head" />
 </head>
-<body class="min-h-screen bg-base-100 text-base-content">
+<body class="min-h-screen flex flex-col bg-base-100 text-base-content">
     <x-tallcms::code-injection zone="body_start" />
     <!-- Header -->
     @if(function_exists('mega_menu_header_active') && mega_menu_header_active('header'))
@@ -101,7 +101,7 @@
     @endif
 
     <!-- Main Content -->
-    <main>
+    <main class="flex-1">
         {{ $slot ?? '' }}
         @yield('content')
     </main>

--- a/packages/tallcms/cms/resources/themes/talldaisy/resources/views/layouts/app.blade.php
+++ b/packages/tallcms/cms/resources/themes/talldaisy/resources/views/layouts/app.blade.php
@@ -82,15 +82,15 @@
     </style>
     <x-tallcms::code-injection zone="head" />
 </head>
-<body class="min-h-screen bg-base-100 text-base-content">
+<body class="min-h-screen flex flex-col bg-base-100 text-base-content">
     <x-tallcms::code-injection zone="body_start" />
     <!-- Navigation Progress Bar -->
     <div class="navigation-progress" id="nav-progress"></div>
     @if(supports_theme_controller())
     <!-- Theme Drawer Wrapper -->
-    <div class="drawer drawer-end">
+    <div class="drawer drawer-end min-h-screen">
         <input id="theme-drawer" type="checkbox" class="drawer-toggle" />
-        <div class="drawer-content">
+        <div class="drawer-content flex flex-col min-h-screen">
     @endif
             <!-- Navbar -->
             @if(function_exists('mega_menu_header_active') && mega_menu_header_active('header'))
@@ -162,7 +162,7 @@
             @endif
 
             <!-- Main Content -->
-            <main>
+            <main class="flex-1">
                 {{ $slot ?? '' }}
                 @yield('content')
             </main>

--- a/packages/tallcms/cms/resources/views/layouts/app.blade.php
+++ b/packages/tallcms/cms/resources/views/layouts/app.blade.php
@@ -70,7 +70,7 @@
 </head>
 <body class="font-inter antialiased bg-white">
     <x-tallcms::code-injection zone="body_start" />
-    <div class="min-h-screen">
+    <div class="min-h-screen flex flex-col">
         @if(!($minimalChrome ?? false))
         <!-- Navigation -->
         <nav x-data="{ open: false }" class="absolute top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-md shadow-sm">
@@ -176,7 +176,7 @@
         @endif
 
         <!-- Main Content -->
-        <main>
+        <main class="flex-1">
             {{ $slot ?? '' }}
             @yield('content')
         </main>

--- a/themes/autumn/resources/views/layouts/app.blade.php
+++ b/themes/autumn/resources/views/layouts/app.blade.php
@@ -43,7 +43,7 @@
     <style>[x-cloak] { display: none !important; }</style>
     <x-tallcms::code-injection zone="head" />
 </head>
-<body class="min-h-screen bg-base-100 text-base-content">
+<body class="min-h-screen flex flex-col bg-base-100 text-base-content">
     <x-tallcms::code-injection zone="body_start" />
     <!-- Header -->
     @if(function_exists('mega_menu_header_active') && mega_menu_header_active('header'))
@@ -101,7 +101,7 @@
     @endif
 
     <!-- Main Content -->
-    <main>
+    <main class="flex-1">
         {{ $slot ?? '' }}
         @yield('content')
     </main>

--- a/themes/blog/resources/views/layouts/app.blade.php
+++ b/themes/blog/resources/views/layouts/app.blade.php
@@ -43,7 +43,7 @@
     <style>[x-cloak] { display: none !important; }</style>
     <x-tallcms::code-injection zone="head" />
 </head>
-<body class="min-h-screen bg-base-100 text-base-content">
+<body class="min-h-screen flex flex-col bg-base-100 text-base-content">
     <x-tallcms::code-injection zone="body_start" />
     <!-- Header -->
     @if(function_exists('mega_menu_header_active') && mega_menu_header_active('header'))
@@ -101,7 +101,7 @@
     @endif
 
     <!-- Main Content -->
-    <main>
+    <main class="flex-1">
         {{ $slot ?? '' }}
         @yield('content')
     </main>

--- a/themes/candy/resources/views/layouts/app.blade.php
+++ b/themes/candy/resources/views/layouts/app.blade.php
@@ -43,7 +43,7 @@
     <style>[x-cloak] { display: none !important; }</style>
     <x-tallcms::code-injection zone="head" />
 </head>
-<body class="min-h-screen bg-base-100 text-base-content">
+<body class="min-h-screen flex flex-col bg-base-100 text-base-content">
     <x-tallcms::code-injection zone="body_start" />
     <!-- Header -->
     @if(function_exists('mega_menu_header_active') && mega_menu_header_active('header'))
@@ -101,7 +101,7 @@
     @endif
 
     <!-- Main Content -->
-    <main>
+    <main class="flex-1">
         {{ $slot ?? '' }}
         @yield('content')
     </main>

--- a/themes/corporate/resources/views/layouts/app.blade.php
+++ b/themes/corporate/resources/views/layouts/app.blade.php
@@ -43,7 +43,7 @@
     <style>[x-cloak] { display: none !important; }</style>
     <x-tallcms::code-injection zone="head" />
 </head>
-<body class="min-h-screen bg-base-100 text-base-content">
+<body class="min-h-screen flex flex-col bg-base-100 text-base-content">
     <x-tallcms::code-injection zone="body_start" />
     <!-- Header -->
     @if(function_exists('mega_menu_header_active') && mega_menu_header_active('header'))
@@ -101,7 +101,7 @@
     @endif
 
     <!-- Main Content -->
-    <main>
+    <main class="flex-1">
         {{ $slot ?? '' }}
         @yield('content')
     </main>

--- a/themes/creative/resources/views/layouts/app.blade.php
+++ b/themes/creative/resources/views/layouts/app.blade.php
@@ -43,7 +43,7 @@
     <style>[x-cloak] { display: none !important; }</style>
     <x-tallcms::code-injection zone="head" />
 </head>
-<body class="min-h-screen bg-base-100 text-base-content">
+<body class="min-h-screen flex flex-col bg-base-100 text-base-content">
     <x-tallcms::code-injection zone="body_start" />
     <!-- Header -->
     @if(function_exists('mega_menu_header_active') && mega_menu_header_active('header'))
@@ -101,7 +101,7 @@
     @endif
 
     <!-- Main Content -->
-    <main>
+    <main class="flex-1">
         {{ $slot ?? '' }}
         @yield('content')
     </main>

--- a/themes/luxury/resources/views/layouts/app.blade.php
+++ b/themes/luxury/resources/views/layouts/app.blade.php
@@ -44,7 +44,7 @@
     <style>[x-cloak] { display: none !important; }</style>
     <x-tallcms::code-injection zone="head" />
 </head>
-<body class="min-h-screen bg-base-100 text-base-content">
+<body class="min-h-screen flex flex-col bg-base-100 text-base-content">
     <x-tallcms::code-injection zone="body_start" />
     <!-- Header -->
     @if(function_exists('mega_menu_header_active') && mega_menu_header_active('header'))
@@ -101,7 +101,7 @@
     @endif
 
     <!-- Main Content -->
-    <main>
+    <main class="flex-1">
         {{ $slot ?? '' }}
         @yield('content')
     </main>

--- a/themes/minimal/resources/views/layouts/app.blade.php
+++ b/themes/minimal/resources/views/layouts/app.blade.php
@@ -43,7 +43,7 @@
     <style>[x-cloak] { display: none !important; }</style>
     <x-tallcms::code-injection zone="head" />
 </head>
-<body class="min-h-screen bg-base-100 text-base-content">
+<body class="min-h-screen flex flex-col bg-base-100 text-base-content">
     <x-tallcms::code-injection zone="body_start" />
     <!-- Header -->
     @if(function_exists('mega_menu_header_active') && mega_menu_header_active('header'))
@@ -101,7 +101,7 @@
     @endif
 
     <!-- Main Content -->
-    <main>
+    <main class="flex-1">
         {{ $slot ?? '' }}
         @yield('content')
     </main>

--- a/themes/talldaisy/resources/views/layouts/app.blade.php
+++ b/themes/talldaisy/resources/views/layouts/app.blade.php
@@ -82,15 +82,15 @@
     </style>
     <x-tallcms::code-injection zone="head" />
 </head>
-<body class="min-h-screen bg-base-100 text-base-content">
+<body class="min-h-screen flex flex-col bg-base-100 text-base-content">
     <x-tallcms::code-injection zone="body_start" />
     <!-- Navigation Progress Bar -->
     <div class="navigation-progress" id="nav-progress"></div>
     @if(supports_theme_controller())
     <!-- Theme Drawer Wrapper -->
-    <div class="drawer drawer-end">
+    <div class="drawer drawer-end min-h-screen">
         <input id="theme-drawer" type="checkbox" class="drawer-toggle" />
-        <div class="drawer-content">
+        <div class="drawer-content flex flex-col min-h-screen">
     @endif
             <!-- Navbar -->
             @if(function_exists('mega_menu_header_active') && mega_menu_header_active('header'))
@@ -162,7 +162,7 @@
             @endif
 
             <!-- Main Content -->
-            <main>
+            <main class="flex-1">
                 {{ $slot ?? '' }}
                 @yield('content')
             </main>


### PR DESCRIPTION
## Summary
- Pin theme footers to the bottom of the viewport on short pages (e.g. empty Galerie), where they previously sat mid-page with empty space below.
- Layouts used `min-h-screen` without a flex column, so the footer followed content height instead of the viewport.
- Apply `min-h-screen flex flex-col` on the page wrapper and `flex-1` on `<main>` across default themes and the CMS layout. For talldaisy, also flex `.drawer-content` so the pin works with the theme drawer.

It looks like this now:
<img width="1912" height="1013" alt="image" src="https://github.com/user-attachments/assets/811c49b6-e01e-479f-80c9-de26c3efe0cd" />


## Test plan
- [ ] Open a short page (sparse content) on talldaisy — footer sits at the bottom of the viewport
- [ ] Open a long page — footer stays after content; normal scrolling unchanged
- [ ] Confirm theme drawer / theme switcher still opens and closes correctly on talldaisy
- [ ] Spot-check another theme (e.g. minimal or elevate) on a short page