### PR TITLE
Fix Theme Manager display options saving to the wrong site

### DIFF
--- a/packages/tallcms/cms/src/Filament/Pages/ThemeManager.php
+++ b/packages/tallcms/cms/src/Filament/Pages/ThemeManager.php
@@ -23,6 +23,7 @@ use TallCms\Cms\Models\SiteSetting;
 use TallCms\Cms\Models\Theme;
 use TallCms\Cms\Services\MarketplaceCatalogService;
 use TallCms\Cms\Services\PluginLicenseService;
+use TallCms\Cms\Services\SiteSettingsService;
 use TallCms\Cms\Services\ThemeManager as ThemeManagerService;
 use TallCms\Cms\Services\ThemeValidator;
 
@@ -98,20 +99,17 @@ class ThemeManager extends Page implements HasForms
 
     public function updatedShowThemeSwitcher(bool $value): void
     {
-        SiteSetting::set('show_theme_switcher', $value, 'boolean', 'branding');
-        SiteSetting::clearCache();
+        $this->writeScopedSetting('show_theme_switcher', $value, 'boolean', 'branding');
     }
 
     public function updatedShowSearch(bool $value): void
     {
-        SiteSetting::set('show_search', $value, 'boolean', 'branding');
-        SiteSetting::clearCache();
+        $this->writeScopedSetting('show_search', $value, 'boolean', 'branding');
     }
 
     public function updatedShowLanguageDropdown(bool $value): void
     {
-        SiteSetting::set('show_language_dropdown', $value, 'boolean', 'branding');
-        SiteSetting::clearCache();
+        $this->writeScopedSetting('show_language_dropdown', $value, 'boolean', 'branding');
     }
 
     /**
@@ -120,6 +118,43 @@ class ThemeManager extends Page implements HasForms
     protected function getThemeManager(): ThemeManagerService
     {
         return app(ThemeManagerService::class);
+    }
+
+    protected function getSiteSettingsService(): SiteSettingsService
+    {
+        return app(SiteSettingsService::class);
+    }
+
+    /**
+     * Persist a Theme Manager setting to the site shown in the page dropdown
+     * (getMultisiteContext), not ambient SiteSetting::set().
+     *
+     * Livewire updates hit /livewire/update without MarkAdminContext, so
+     * SiteSetting::set() can follow the admin hostname (e.g. 127.0.0.1.nip.io)
+     * instead of the tenant selected in Theme Manager.
+     */
+    protected function writeScopedSetting(string $key, mixed $value, string $type, string $group): void
+    {
+        $context = $this->getMultisiteContext();
+
+        if ($context) {
+            $this->getSiteSettingsService()->setForSite((int) $context->id, $key, $value, $type);
+        } else {
+            SiteSetting::setGlobal($key, $value, $type, $group);
+        }
+
+        SiteSetting::clearCache();
+    }
+
+    protected function readScopedSetting(string $key, mixed $default = null): mixed
+    {
+        $context = $this->getMultisiteContext();
+
+        if ($context) {
+            return $this->getSiteSettingsService()->getForSite((int) $context->id, $key, $default);
+        }
+
+        return SiteSetting::getGlobal($key, $default);
     }
 
     /**
@@ -463,14 +498,10 @@ class ThemeManager extends Page implements HasForms
             $fallback = $activeThemeModel?->getDaisyUIPreset() ?? 'light';
             $presets = $activeThemeModel?->getDaisyUIPresets() ?? [];
 
-            // SiteSetting::get() resolves to the active site's override (or the
-            // default site's override on standalone installs, post-4.0.8), and
-            // falls back to the global value when no override exists. The older
-            // branching on getMultisiteContext() predates the default-site
-            // resolver fallback and silently skipped the override on standalone
-            // installs — save went to the override table, read hit the globals
-            // table, so the preset never persisted.
-            $stored = SiteSetting::get('theme_default_preset');
+            // SiteSetting::get() follows the request host / admin_context, which
+            // on Livewire updates is often the platform domain rather than the
+            // site selected in Theme Manager. Read the dropdown site explicitly.
+            $stored = $this->readScopedSetting('theme_default_preset');
 
             $theme['defaultPreset'] = ($stored && in_array($stored, $presets)) ? $stored : $fallback;
         }
@@ -582,8 +613,7 @@ class ThemeManager extends Page implements HasForms
                 }
             }
 
-            // Clear preset for this site (SiteSetting::set() is site-aware)
-            SiteSetting::set('theme_default_preset', '', 'text', 'theme');
+            $this->writeScopedSetting('theme_default_preset', '', 'text', 'theme');
 
             Notification::make()
                 ->title(__('tallcms::ui.t_site_theme_updated'))
@@ -594,7 +624,7 @@ class ThemeManager extends Page implements HasForms
             $this->clearThemeCache();
         } elseif ($this->getThemeManager()->activateWithRollback($slug)) {
             // Global: write to config/theme.php with rollback support
-            SiteSetting::set('theme_default_preset', '', 'text', 'theme');
+            $this->writeScopedSetting('theme_default_preset', '', 'text', 'theme');
 
             Notification::make()
                 ->title(__('tallcms::ui.t_theme_activated'))
@@ -721,7 +751,7 @@ class ThemeManager extends Page implements HasForms
             return;
         }
 
-        SiteSetting::set('theme_default_preset', $preset, 'text', 'theme', 'Default daisyUI preset for the active theme');
+        $this->writeScopedSetting('theme_default_preset', $preset, 'text', 'theme');
 
         Notification::make()
             ->title(__('tallcms::ui.t_default_preset_updated'))
@@ -791,9 +821,9 @@ class ThemeManager extends Page implements HasForms
         // site-wide SiteSetting values and would be misleading when shown for
         // an inactive theme. The Blade also gates on isActive for the same reason.
         if ($activeSlug === $theme->slug) {
-            $this->showThemeSwitcher = (bool) SiteSetting::get('show_theme_switcher', true);
-            $this->showSearch = (bool) SiteSetting::get('show_search', true);
-            $this->showLanguageDropdown = (bool) SiteSetting::get('show_language_dropdown', true);
+            $this->showThemeSwitcher = (bool) $this->readScopedSetting('show_theme_switcher', true);
+            $this->showSearch = (bool) $this->readScopedSetting('show_search', true);
+            $this->showLanguageDropdown = (bool) $this->readScopedSetting('show_language_dropdown', true);
         }
 
         $this->dispatch('open-modal', id: 'theme-details-modal');

--- a/tests/Feature/ThemeManagerDisplayOptionsScopingTest.php
+++ b/tests/Feature/ThemeManagerDisplayOptionsScopingTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Spatie\Permission\Models\Role;
+use TallCms\Cms\Filament\Pages\ThemeManager;
+use TallCms\Cms\Models\SiteSetting;
+use Tests\TestCase;
+
+/**
+ * Display Options / default preset must follow Theme Manager's selected site,
+ * not the admin request hostname.
+ *
+ * Repro: super_admin on 127.0.0.1.nip.io picks Ponyhof in the Theme Manager
+ * dropdown and turns the theme switcher off. Ambient SiteSetting::set() on
+ * the Livewire update resolved the Host site instead, so Ponyhof kept the
+ * global default (on).
+ */
+class ThemeManagerDisplayOptionsScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! Schema::hasTable('tallcms_sites')) {
+            $this->markTestSkipped('tallcms_sites table is not available.');
+        }
+
+        Cache::flush();
+        SiteSetting::forgetMemoizedDefaultSiteId();
+
+        Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web']);
+    }
+
+    public function test_display_option_toggle_writes_to_session_site_not_hostname_site(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('super_admin');
+        $this->actingAs($admin);
+
+        $hostSiteId = $this->insertSite('TallCMS', '127.0.0.1.nip.io');
+        $ponyhofId = $this->insertSite('Ponyhof Club', 'ponyhof-club.127.0.0.1.nip.io');
+
+        $this->bindHostnameResolver($hostSiteId);
+        request()->attributes->set('tallcms.admin_context', false);
+        session(['multisite_admin_site_id' => $ponyhofId]);
+
+        $page = new ThemeManager;
+        $page->updatedShowThemeSwitcher(false);
+        $page->updatedShowSearch(false);
+        $page->updatedShowLanguageDropdown(false);
+
+        $this->assertSame('0', $this->overrideValue($ponyhofId, 'show_theme_switcher'));
+        $this->assertSame('0', $this->overrideValue($ponyhofId, 'show_search'));
+        $this->assertSame('0', $this->overrideValue($ponyhofId, 'show_language_dropdown'));
+
+        $this->assertNull(
+            $this->overrideValue($hostSiteId, 'show_theme_switcher'),
+            'Display Options must not land on the admin hostname site.',
+        );
+        $this->assertNull($this->overrideValue($hostSiteId, 'show_search'));
+        $this->assertNull($this->overrideValue($hostSiteId, 'show_language_dropdown'));
+    }
+
+    public function test_display_option_hydrate_reads_session_site_not_hostname_site(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('super_admin');
+        $this->actingAs($admin);
+
+        $hostSiteId = $this->insertSite('TallCMS', '127.0.0.1.nip.io');
+        $ponyhofId = $this->insertSite('Ponyhof Club', 'ponyhof-club.127.0.0.1.nip.io');
+
+        DB::table('tallcms_site_setting_overrides')->insert([
+            'site_id' => $ponyhofId,
+            'key' => 'show_theme_switcher',
+            'value' => '0',
+            'type' => 'boolean',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        DB::table('tallcms_site_settings')->insert([
+            'key' => 'show_theme_switcher',
+            'value' => '1',
+            'type' => 'boolean',
+            'group' => 'branding',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->bindHostnameResolver($hostSiteId);
+        request()->attributes->set('tallcms.admin_context', false);
+        session(['multisite_admin_site_id' => $ponyhofId]);
+
+        $page = new ThemeManager;
+        $read = new \ReflectionMethod($page, 'readScopedSetting');
+        $read->setAccessible(true);
+
+        $this->assertFalse(
+            (bool) $read->invoke($page, 'show_theme_switcher', true),
+            'Hydration must use the Theme Manager session site (Ponyhof off), not global/host on.',
+        );
+    }
+
+    public function test_super_admin_without_session_site_writes_global_not_hostname_override(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('super_admin');
+        $this->actingAs($admin);
+
+        $hostSiteId = $this->insertSite('TallCMS', '127.0.0.1.nip.io');
+
+        $this->bindHostnameResolver($hostSiteId);
+        request()->attributes->set('tallcms.admin_context', false);
+        session()->forget('multisite_admin_site_id');
+
+        $page = new ThemeManager;
+        $page->updatedShowThemeSwitcher(false);
+
+        $this->assertNull($this->overrideValue($hostSiteId, 'show_theme_switcher'));
+        $this->assertSame(
+            '0',
+            DB::table('tallcms_site_settings')->where('key', 'show_theme_switcher')->value('value'),
+        );
+    }
+
+    protected function insertSite(string $name, string $domain): int
+    {
+        return (int) DB::table('tallcms_sites')->insertGetId([
+            'name' => $name,
+            'domain' => $domain,
+            'uuid' => (string) Str::uuid(),
+            'is_active' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    protected function overrideValue(int $siteId, string $key): ?string
+    {
+        $value = DB::table('tallcms_site_setting_overrides')
+            ->where('site_id', $siteId)
+            ->where('key', $key)
+            ->value('value');
+
+        return $value === null ? null : (string) $value;
+    }
+
+    /**
+     * Mimic a Livewire update whose Host matches the platform site, while
+     * Theme Manager's dropdown session points at another tenant.
+     */
+    protected function bindHostnameResolver(int $hostSiteId): void
+    {
+        $this->app->instance('tallcms.multisite.resolver', new class($hostSiteId)
+        {
+            public function __construct(private int $hostSiteId) {}
+
+            public function isResolved(): bool
+            {
+                return true;
+            }
+
+            public function id(): int
+            {
+                return $this->hostSiteId;
+            }
+
+            public function reset(): void {}
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Theme Manager Display Options and the default daisyUI preset now read/write the site selected in Theme Manager (or global when none is selected), instead of ambient `SiteSetting::set()`.
- Livewire updates were resolving settings from the admin request host, so toggling controls for a selected tenant persisted on the platform/default site while that tenant’s public site kept the global defaults.
- Standalone installs are unchanged: no site context still goes to the global settings row, which the frontend already falls back to.

## Test plan
- [ ] `php artisan test --compact tests/Feature/ThemeManagerDisplayOptionsScopingTest.php`
- [ ] Multisite: in Theme Manager, select tenant A (not the admin host), turn Theme switcher / Search / Language off, confirm overrides land on tenant A and the public tenant URL hides those controls.
- [ ] Confirm tenant B / the admin-host site are unaffected.
- [ ] Standalone (no site dropdown): toggle Display Options and confirm the frontend still follows the change.